### PR TITLE
ignore generated Visual Studio solution files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,13 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 
+# Visual Studio files
+*.vcproj
+*.sdf
+*.suo
+*.vcxproj
+*.vcxproj.filters
+*.sln
 
 ### OSX ###
 .DS_Store


### PR DESCRIPTION
This is a small patch for Windows users.
