### PR TITLE
report MSVC target architecture

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -65,6 +65,17 @@ def vc_version():
 	print 'cannot identify compiler version'
 	Exit(1)
 
+#run cl (MSVC compiler) and return the target architecture (x64 or x86)
+def cl_target_arch():
+    cl = subprocess.Popen('cl.exe /?', stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+    for line in cl.stdout:
+        if re.search('for x64', line):
+            return 'x64'
+        elif re.search('for x86', line):
+            return 'x86'
+        break
+    raise Exception("Could not determine target architecture for cl.exe")
+
 def Mac_m64_Capable():
 	return execute('sysctl -n hw.optional.x86_64'.split()).strip() == '1'
 
@@ -124,10 +135,12 @@ AddOption('--opt', action='store_true', dest='opt', default=False, help='Enable 
 
 AddOption('--verbose', action='store_true', dest='verbose', default=False, help='Output full compiler commands')
 
-
 msvc_version = "12.0"
+cl_target_architecture = ''
 if sys.platform == 'win32':
-	msvc_version = vc_version()
+    msvc_version = vc_version()
+    cl_target_architecture = cl_target_arch()
+    print "MSVC compiler target architecture is", cl_target_architecture
 
 env = Environment(
 	MSVC_VERSION=msvc_version,
@@ -254,22 +267,19 @@ Export('env')
 g_msvs_variant = 'Debug|Win32'
 
 if 'MSVSSolution' in env['BUILDERS']:
-	msvs_projs = []
-	Export('msvs_projs')
+    msvs_projs = []
+    Export('msvs_projs')
 
-	cl = subprocess.Popen('cl.exe /?', stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-	for line in cl.stdout:
-		if re.search('x64', line):
-			if GetOption('opt'):
-				g_msvs_variant = 'Release|x64'
-			else:
-				g_msvs_variant = 'Debug|x64'
-		else:
-			if GetOption('opt'):
-				g_msvs_variant = 'Release|Win32'
-			else:
-				g_msvs_variant = 'Debug|Win32'
-		break
+    if (cl_target_architecture == 'x64'):
+        if GetOption('opt'):
+            g_msvs_variant = 'Release|x64'
+        else:
+            g_msvs_variant = 'Debug|x64'
+    else:
+        if GetOption('opt'):
+            g_msvs_variant = 'Release|Win32'
+        else:
+            g_msvs_variant = 'Debug|Win32'
 
 Export('g_msvs_variant')
 


### PR DESCRIPTION
Report the MSVC target architecture during the build since Windows
users have to pick the correct one. The target architecture was already
being checked in order to set `g_msvs_variant`, so just move the logic
into a function, store it in a variable and use the result for both
actions. Helps with #165.

I tested the message and the value of `g_msvs_variant` with the x86 and x64 VS command prompts.
