### PR TITLE
allow compiling out SVS

### DIFF
--- a/Core/CLI/CommandLineInterface.cxx
+++ b/Core/CLI/CommandLineInterface.cxx
@@ -64,7 +64,9 @@
 #include "src/cli_srand.cpp"
 #include "src/cli_stats.cpp"
 #include "src/cli_stopsoar.cpp"
+#ifndef NO_SVS
 #include "src/cli_svs.cpp"
+#endif
 #include "src/cli_time.cpp"
 #include "src/cli_timers.cpp"
 #include "src/cli_unalias.cpp"

--- a/Core/CLI/src/cli_Cli.h
+++ b/Core/CLI/src/cli_Cli.h
@@ -17,9 +17,9 @@ namespace cli
     {
         public:
             virtual ~Cli() {}
-            
+
             virtual bool SetError(const std::string& error) = 0;
-            
+
             /**
              * @brief add-wme command
              * @param id Id string for the new wme
@@ -28,7 +28,7 @@ namespace cli
              * @param acceptable True to give wme acceptable preference
              */
             virtual bool DoAddWME(const std::string& id, std::string attribute, const std::string& value, bool acceptable) = 0;
-            
+
             /**
              * @brief alias command
              * @param argv Alias command arguments with the command name removed.
@@ -36,33 +36,33 @@ namespace cli
              *        Null to list.
              */
             virtual bool DoAlias(std::vector< std::string >* argv = 0) = 0;
-            
+
             virtual bool DoAllocate(const std::string& pool, int blocks) = 0;
-            
+
             enum eCaptureInputMode
             {
                 CAPTURE_INPUT_OPEN,
                 CAPTURE_INPUT_QUERY,
                 CAPTURE_INPUT_CLOSE,
             };
-            
+
             /**
              * @brief capture-input command
              */
             virtual bool DoCaptureInput(eCaptureInputMode mode, bool autoflush = false, std::string* pathname = 0) = 0;
-            
+
             /**
              * @brief cli command
              */
             virtual bool DoCLIMessage(const std::string& pMessage) = 0;
-            
+
             /**
              * @brief cd command
              * @param pDirectory Pointer to the directory to pass in to. Pass null to return
              *        to the initial (home) directory.
              */
             virtual bool DoCD(const std::string* pDirectory = 0) = 0;
-            
+
             /**
              * @brief chunk-name-format command
              * @param pLongFormat Pointer to the new format type, true for long format, false
@@ -72,7 +72,7 @@ namespace cli
              *        null for query
              */
             virtual bool DoChunkNameFormat(const chunkNameFormats* chunkNameFormat = 0, const int64_t* pCount = 0, const std::string* pPrefix = 0) = 0;
-            
+
             enum eLogMode
             {
                 LOG_QUERY,
@@ -81,7 +81,7 @@ namespace cli
                 LOG_CLOSE,
                 LOG_ADD,
             };
-            
+
             /**
              * @brief clog command
              * @param mode The mode for the log command
@@ -90,47 +90,47 @@ namespace cli
              * @param silent Supress query messages (log file open/closed).
              */
             virtual bool DoCLog(const eLogMode mode = LOG_QUERY, const std::string* pFilename = 0, const std::string* pToAdd = 0, bool silent = false) = 0;
-            
+
             virtual bool DoCommandToFile(const eLogMode mode, const std::string& filename, std::vector< std::string >& argv) = 0;
-            
+
             /**
              * @brief debug command
              *
              */
             virtual bool DoDebug(std::vector< std::string >* argv = 0) = 0;
-            
+
             /**
              * @brief default-wme-depth command
              * @param pDepth The pointer to the new wme depth, a positive integer.
              *        Pass 0 (null) pointer for query.
              */
             virtual bool DoDefaultWMEDepth(const int* pDepth) = 0;
-            
+
             /**
              * @brief dirs command
              */
             virtual bool DoDirs() = 0;
-            
+
             /**
              * @brief echo command
              * @param argv The args to echo
              * @param echoNewline True means a newline character will be appended to string
              */
             virtual bool DoEcho(const std::vector<std::string>& argv, bool echoNewline) = 0;
-            
+
             /**
              * @brief echo-commands command
              * @param onlyGetValue
              * @param echoCommands
              */
             virtual bool DoEchoCommands(bool onlyGetValue, bool echoCommands) = 0;
-            
+
             /**
              * @brief edit-production command
              * @param productionName Production to edit
              */
             virtual bool DoEditProduction(std::string productionName) = 0;
-            
+
             /**
              * @brief epmem command
              * @param pOp the epmem switch to implement, pass 0 (null) for full parameter configuration
@@ -138,7 +138,7 @@ namespace cli
              * @param pVal the value to set, pass 0 (null) only if no pOp (all config), get, or stats
              */
             virtual bool DoEpMem(const char pOp = 0, const std::string* pAttr = 0, const std::string* pVal = 0, const epmem_time_id memory_id = 0) = 0;
-            
+
             enum eExciseOptions
             {
                 EXCISE_ALL,
@@ -151,14 +151,14 @@ namespace cli
                 EXCISE_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<EXCISE_NUM_OPTIONS> ExciseBitset;
-            
+
             /**
              * @brief excise command
              * @param options The various options set on the command line
              * @param pProduction A production to excise, optional
              */
             virtual bool DoExcise(const ExciseBitset& options, const std::string* pProduction = 0) = 0;
-            
+
             /**
              * @brief explain-backtraces command
              * @param pProduction Pointer to involved production. Pass 0 (null) for
@@ -168,7 +168,7 @@ namespace cli
              *        this argument ignored if pProduction is 0 (null)
              */
             virtual bool DoExplainBacktraces(const std::string* pProduction = 0, const int condition = 0) = 0;
-            
+
             /**
              * @brief firing-counts command
              * @param numberToList The number of top-firing productions to list.
@@ -177,29 +177,29 @@ namespace cli
              *        multiple productions
              */
             virtual bool DoFiringCounts(const int numberToList = -1, const std::string* pProduction = 0) = 0;
-            
+
             /**
              * @brief gds-print command
              */
             virtual bool DoGDSPrint() = 0;
-            
+
             /**
              * @brief gp command
              * @param productionString The general soar production to generate more productions to load to memory
              */
             virtual bool DoGP(const std::string& productionString) = 0;
-            
+
             /**
              * @brief gp-max command
              * @param maximum The maximum number of productions to allow generation of
              */
             virtual bool DoGPMax(const int& maximum) = 0;
-            
+
             /**
              * @brief help command
              */
             virtual bool DoHelp(const std::vector<std::string>& argv) = 0;
-            
+
             /**
              * @brief indifferent-selection command
              * @param pOp The operation to perform, pass 0 if unnecssary
@@ -208,17 +208,17 @@ namespace cli
              * @param p3 Third parameter, pass 0 (null) if unnecessary
              */
             virtual bool DoIndifferentSelection(const char pOp = 0, const std::string* p1 = 0, const std::string* p2 = 0, const std::string* p3 = 0) = 0;
-            
+
             /**
              * @brief init-soar command
              */
             virtual bool DoInitSoar() = 0;
-            
+
             /**
              * @brief internal-symbols command
              */
             virtual bool DoInternalSymbols() = 0;
-            
+
             enum eLearnOptions
             {
                 LEARN_ALL_LEVELS,
@@ -235,25 +235,25 @@ namespace cli
                 LEARN_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<LEARN_NUM_OPTIONS> LearnBitset;
-            
+
             /**
              * @brief learn command
              * @param options The various options set on the command line
              */
             virtual bool DoLearn(const LearnBitset& options) = 0;
-            
+
             /**
              * @brief load-library command
              * @param libraryCommand The name of the library to load
              * WITHOUT the .so/.dll/etc plus its arguments.
              */
             virtual bool DoLoadLibrary(const std::string& libraryCommand) = 0;
-            
+
             /**
              * @brief ls command
              */
             virtual bool DoLS() = 0;
-            
+
             enum eMatchesMode
             {
                 MATCHES_PRODUCTION,
@@ -261,14 +261,14 @@ namespace cli
                 MATCHES_RETRACTIONS,
                 MATCHES_ASSERTIONS_RETRACTIONS,
             };
-            
+
             enum eWMEDetail
             {
                 WME_DETAIL_NONE,
                 WME_DETAIL_TIMETAG,
                 WME_DETAIL_FULL,
             };
-            
+
             /**
              * @brief matches command
              * @param mode The mode for the command
@@ -276,13 +276,13 @@ namespace cli
              * @param pProduction The production, pass 0 (null) if not applicable to mode
              */
             virtual bool DoMatches(const eMatchesMode mode, const eWMEDetail detail = WME_DETAIL_NONE, const std::string* pProduction = 0) = 0;
-            
+
             /**
              * @brief max-chunks command
              * @param n The new max chunks value, use 0 to query
              */
             virtual bool DoMaxChunks(const int n = 0) = 0;
-            
+
             /**
              * @brief max-dc-time command
              * @param n The new max dc time value in microseconds, use
@@ -294,25 +294,25 @@ namespace cli
              * @param n The new max elaborations value, use 0 to query
              */
             virtual bool DoMaxElaborations(const int n = 0) = 0;
-            
+
             /**
              * @brief max-goal-depth command
              * @param n The new max goal depth value, use 0 to query
              */
             virtual bool DoMaxGoalDepth(const int n = 0) = 0;
-            
+
             /**
              * @brief max-memory-usage command
              * @param n The new memory usage value, in bytes
              */
             virtual bool DoMaxMemoryUsage(const int n = 0) = 0;
-            
+
             /**
              * @brief max-nil-output-cycles command
              * @param n The new max nil output cycles value, use 0 to query
              */
             virtual bool DoMaxNilOutputCycles(const int n = 0) = 0;
-            
+
             enum eMemoriesOptions
             {
                 MEMORIES_CHUNKS,
@@ -323,7 +323,7 @@ namespace cli
                 MEMORIES_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<MEMORIES_NUM_OPTIONS> MemoriesBitset;
-            
+
             /**
              * @brief memories command
              * @param options Options for the memories flag
@@ -332,7 +332,7 @@ namespace cli
              *        options are set, pass 0 (null) if not applicable
              */
             virtual bool DoMemories(const MemoriesBitset options, int n = 0, const std::string* pProduction = 0) = 0;
-            
+
             /**
              * @brief multi-attributes command
              * @param pAttribute The attribute, pass 0 (null) for query
@@ -340,41 +340,41 @@ namespace cli
              *        otherwise this will default to 10
              */
             virtual bool DoMultiAttributes(const std::string* pAttribute = 0, int n = 0) = 0;
-            
+
             /**
              * @brief numeric-indifferent mode command
              * @param query true to query
              * @param mode The new mode, ignored on query
              */
             virtual bool DoNumericIndifferentMode(bool query, const ni_mode mode) = 0;
-            
+
             /**
              * @brief o-support-mode command
              * @param mode The new o-support mode.  Use -1 to query.
              */
             virtual bool DoOSupportMode(int mode = -1) = 0;
-            
+
             /**
              * @brief pbreak command
              * @param pProduction The production
              */
             virtual bool DoPbreak(const char& mode, const std::string& production) = 0;
-            
+
             /**
              * @brief popd command
              */
             virtual bool DoPopD() = 0;
-            
+
             /**
              * @brief port command
              */
             virtual bool DoPort() = 0;
-            
+
             /**
              * @brief predict command
              */
             virtual bool DoPredict() = 0;
-            
+
             enum ePreferencesDetail
             {
                 PREFERENCES_ONLY,
@@ -382,7 +382,7 @@ namespace cli
                 PREFERENCES_TIMETAGS,
                 PREFERENCES_WMES,
             };
-            
+
             /**
              * @brief preferences command
              * @param detail The preferences detail level
@@ -390,7 +390,7 @@ namespace cli
              * @param pAttribute An existing soar attribute of the specified identifier or 0 (null)
              */
             virtual bool DoPreferences(const ePreferencesDetail detail, const bool object, const std::string* pId = 0, const std::string* pAttribute = 0) = 0;
-            
+
             enum ePrintOptions
             {
                 PRINT_ALL,
@@ -414,7 +414,7 @@ namespace cli
                 PRINT_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<PRINT_NUM_OPTIONS> PrintBitset;
-            
+
             /**
              * @brief print command
              * @param options The options to the print command
@@ -423,7 +423,7 @@ namespace cli
              *        or 0 (null) if not applicable
              */
             virtual bool DoPrint(PrintBitset options, int depth, const std::string* pArg = 0) = 0;
-            
+
             enum eProductionFindOptions
             {
                 PRODUCTION_FIND_INCLUDE_LHS,
@@ -434,20 +434,20 @@ namespace cli
                 PRODUCTION_FIND_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<PRODUCTION_FIND_NUM_OPTIONS> ProductionFindBitset;
-            
+
             /**
              * @brief production-find command
              * @param options The options to the command
              * @param pattern Any pattern that can appear in productions.
              */
             virtual bool DoProductionFind(const ProductionFindBitset& options, const std::string& pattern) = 0;
-            
+
             /**
              * @brief pushd command
              * @param directory The directory to change to
              */
             virtual bool DoPushD(const std::string& directory) = 0;
-            
+
             /**
              * @brief pwatch command
              * @param query Pass true to query, all other args ignored
@@ -456,42 +456,42 @@ namespace cli
              * @param setting True to watch the pProduction, false to stop watching it
              */
             virtual bool DoPWatch(bool query = true, const std::string* pProduction = 0, bool setting = false) = 0;
-            
+
             /**
              * @brief pwd command
              */
             virtual bool DoPWD() = 0;
-            
+
             /**
              * @brief rand command
              */
             virtual bool DoRand(bool integer, std::string* bound) = 0;
-            
+
             /**
              * @brief remove-wme command
              * @param timetag The timetag of the wme to remove
              */
             virtual bool DoRemoveWME(uint64_t timetag) = 0;
-            
+
             enum eReplayInputMode
             {
                 REPLAY_INPUT_OPEN,
                 REPLAY_INPUT_QUERY,
                 REPLAY_INPUT_CLOSE,
             };
-            
+
             /**
              * @brief replay-input command
              */
             virtual bool DoReplayInput(eReplayInputMode mode, std::string* pathname) = 0;
-            
+
             /**
              * @brief rete-net command
              * @param save true to save, false to load
              * @param filename the rete-net file
              */
             virtual bool DoReteNet(bool save, std::string filename) = 0;
-            
+
             /**
              * @brief rl command
              * @param pOp the rl switch to implement, pass 0 (null) for full parameter configuration
@@ -499,9 +499,10 @@ namespace cli
              * @param pVal the value to set, pass 0 (null) only if no pOp (all config), get, or stats
              */
             virtual bool DoRL(const char pOp = 0, const std::string* pAttr = 0, const std::string* pVal = 0) = 0;
-            
+
+#ifndef NO_SVS
             virtual bool DoSVS(const std::vector<std::string>& args) = 0;
-            
+#endif
             enum eRunOptions
             {
                 RUN_DECISION,
@@ -517,7 +518,7 @@ namespace cli
                 RUN_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<RUN_NUM_OPTIONS> RunBitset;
-            
+
             enum eRunInterleaveMode
             {
                 RUN_INTERLEAVE_DEFAULT,
@@ -526,7 +527,7 @@ namespace cli
                 RUN_INTERLEAVE_DECISION,
                 RUN_INTERLEAVE_OUTPUT,
             };
-            
+
             /**
              * @brief run command
              * @param options Options for the run command
@@ -535,20 +536,20 @@ namespace cli
              *         at a finer grain than the run-size parameter.
              */
             virtual bool DoRun(const RunBitset& options, int count = 0, eRunInterleaveMode interleave = RUN_INTERLEAVE_DEFAULT) = 0;
-            
+
             /**
              * @brief save-backtraces command
              * @param setting The new setting, pass 0 (null) for query
              */
             virtual bool DoSaveBacktraces(bool* pSetting = 0) = 0;
-            
+
             /**
              * @brief select command
              * @param pAgent The pointer to the gSKI agent interface
              * @param setting The new setting, pass 0 (null) for query
              */
             virtual bool DoSelect(const std::string* pOp = 0) = 0;
-            
+
             /**
              * @brief set-stop-phase command
              * @param setPhase
@@ -556,7 +557,7 @@ namespace cli
              * @param phase
              */
             virtual bool DoSetStopPhase(bool setPhase, bool before, sml::smlPhase phase) = 0;
-            
+
             /**
              * @brief smem command
              * @param pOp the smem switch to implement, pass 0 (null) for full parameter configuration
@@ -564,12 +565,12 @@ namespace cli
              * @param pVal the value to set, pass 0 (null) only if no pOp (all config), get, or stats
              */
             virtual bool DoSMem(const char pOp = 0, const std::string* pAttr = 0, const std::string* pVal = 0) = 0;
-            
+
             /**
              * @brief soarnews command
              */
             virtual bool DoSoarNews() = 0;
-            
+
             enum eSourceOptions
             {
                 SOURCE_ALL,
@@ -578,26 +579,26 @@ namespace cli
                 SOURCE_NUM_OPTIONS,    // must be last
             };
             typedef std::bitset<SOURCE_NUM_OPTIONS> SourceBitset;
-            
+
             /**
              * @brief source command
              * @param filename The file to source
              */
             virtual bool DoSource(std::string filename, SourceBitset* pOptions = 0) = 0;
-            
+
             /**
              * @brief sp command
              * @param production The production to add to working memory
              */
             virtual bool DoSP(const std::string& production) = 0;
-            
+
             /**
              * @brief srand command
              * @param pSeed Number to seed the random number generator with, pass
              *         null to seed randomly.
              */
             virtual bool DoSRand(uint32_t* pSeed = 0) = 0;
-            
+
             enum eStatsOptions
             {
                 STATS_MEMORY,
@@ -614,62 +615,62 @@ namespace cli
                 STATS_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<STATS_NUM_OPTIONS> StatsBitset;
-            
+
             /**
              * @brief stats command
              * @param options The options for the stats command
              * @param sort The column to sort by
              */
             virtual bool DoStats(const StatsBitset& options, int sort = 0) = 0;
-            
+
             /**
              * @brief stop-soar command
              * @param self Stop the only pAgent (false means stop all agents in kernel)
              * @param reasonForStopping optional reason for stopping
              */
             virtual bool DoStopSoar(bool self, const std::string* reasonForStopping = 0) = 0;
-            
+
             /**
              * @brief time command
              * @param argv The command line with the time arg removed
              */
             virtual bool DoTime(std::vector<std::string>& argv) = 0;
-            
+
             /**
              * @brief timers command
              * @param pSetting The timers setting, true to turn on, false to turn off,
              *        pass 0 (null) to query
              */
             virtual bool DoTimers(bool* pSetting = 0) = 0;
-            
+
             virtual bool DoUnalias(std::vector<std::string>& argv) = 0;
-            
+
             /**
              * @brief verbose command
              * @param pSetting The verbose setting, true to turn on, false to turn off,
              *        pass 0 (null) to query
              */
             virtual bool DoVerbose(bool* pSetting = 0) = 0;
-            
+
             /**
              * @brief version command
              */
             virtual bool DoVersion() = 0;
-            
+
             /**
              * @brief waitsnc command
              * @param pSetting The waitsnc setting, true to turn on, false to turn off,
              *        pass 0 (null) to query
              */
             virtual bool DoWaitSNC(bool* pSetting = 0) = 0;
-            
+
             /**
              * @brief warnings command
              * @param pSetting The warnings setting, true to turn on, false to turn off,
              *        pass 0 (null) to query
              */
             virtual bool DoWarnings(bool* pSetting = 0) = 0;
-            
+
             enum eWatchOptions
             {
                 WATCH_DECISIONS,
@@ -694,7 +695,7 @@ namespace cli
                 WATCH_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<WATCH_NUM_OPTIONS> WatchBitset;
-            
+
             /**
              * @brief watch command
              * @param options Options for the watch command
@@ -704,7 +705,7 @@ namespace cli
              * @param learnSetting Setting for learn level, not binary so it has its own arg
              */
             virtual bool DoWatch(const WatchBitset& options, const WatchBitset& settings, const int wmeSetting, const int learnSetting) = 0;
-            
+
             enum eWatchWMEsMode
             {
                 WATCH_WMES_ADD,
@@ -712,7 +713,7 @@ namespace cli
                 WATCH_WMES_LIST,
                 WATCH_WMES_RESET,
             };
-            
+
             enum eWatchWMEsOptions
             {
                 WATCH_WMES_TYPE_ADDS,
@@ -720,12 +721,12 @@ namespace cli
                 WATCH_WMES_TYPE_NUM_OPTIONS, // must be last
             };
             typedef std::bitset<WATCH_WMES_TYPE_NUM_OPTIONS> WatchWMEsTypeBitset;
-            
+
             /**
              * @brief watch-wmes command
              */
             virtual bool DoWatchWMEs(const eWatchWMEsMode mode, WatchWMEsTypeBitset type, const std::string* pIdString = 0, const std::string* pAttributeString = 0, const std::string* pValueString = 0) = 0;
-            
+
             /**
              * @brief wma command
              * @param pOp the wma switch to implement, pass 0 (null) for full parameter configuration
@@ -733,7 +734,7 @@ namespace cli
              * @param pVal the value to set, pass 0 (null) only if no pOp (all config), get, or stats
              */
             virtual bool DoWMA(const char pOp = 0, const std::string* pAttr = 0, const std::string* pVal = 0) = 0;
-            
+
     };
 }
 

--- a/Core/CLI/src/cli_CommandLineInterface.cpp
+++ b/Core/CLI/src/cli_CommandLineInterface.cpp
@@ -114,7 +114,9 @@ EXPORT CommandLineInterface::CommandLineInterface()
     m_Parser.AddCommand(new cli::WatchCommand(*this));
     m_Parser.AddCommand(new cli::WatchWMEsCommand(*this));
     m_Parser.AddCommand(new cli::WMACommand(*this));
+#ifndef NO_SVS
     m_Parser.AddCommand(new cli::SVSCommand(*this));
+#endif
 }
 
 EXPORT CommandLineInterface::~CommandLineInterface()

--- a/Core/CLI/src/cli_CommandLineInterface.h
+++ b/Core/CLI/src/cli_CommandLineInterface.h
@@ -190,8 +190,9 @@ namespace cli
             virtual bool DoWatch(const WatchBitset& options, const WatchBitset& settings, const int wmeSetting, const int learnSetting);
             virtual bool DoWatchWMEs(const eWatchWMEsMode mode, WatchWMEsTypeBitset type, const std::string* pIdString = 0, const std::string* pAttributeString = 0, const std::string* pValueString = 0);
             virtual bool DoWMA(const char pOp = 0, const std::string* pAttr = 0, const std::string* pVal = 0);
+#ifndef NO_SVS
             bool DoSVS(const std::vector<std::string>& args);
-
+#endif
             // utility for kernel SML
             bool IsLogOpen();
 

--- a/Core/CLI/src/cli_Commands.h
+++ b/Core/CLI/src/cli_Commands.h
@@ -19,21 +19,21 @@ namespace cli
             {
                 return "add-wme";
             }
-            
+
             virtual const char* GetSyntax() const
             {
                 return "Syntax: add-wme id [^]attribute value [+]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() < 4)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 unsigned attributeIndex = (argv[2] == "^") ? 3 : 2;
-                
+
                 if (argv.size() < (attributeIndex + 2))
                 {
                     return cli.SetError(GetSyntax());
@@ -42,7 +42,7 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 bool acceptable = false;
                 if (argv.size() > (attributeIndex + 2))
                 {
@@ -52,16 +52,16 @@ namespace cli
                     }
                     acceptable = true;
                 }
-                
+
                 return cli.DoAddWME(argv[1], argv[attributeIndex], argv[attributeIndex + 1], acceptable);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             AddWMECommand& operator=(const AddWMECommand&);
     };
-    
+
     class AliasCommand : public cli::ParserCommand
     {
         public:
@@ -75,25 +75,25 @@ namespace cli
             {
                 return "Syntax: alias [name [cmd [args]]]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() == 1)
                 {
                     return cli.DoAlias();    // list all
                 }
-                
+
                 argv.erase(argv.begin());
-                
+
                 return cli.DoAlias(&argv);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             AliasCommand& operator=(const AliasCommand&);
     };
-    
+
     class AllocateCommand : public cli::ParserCommand
     {
         public:
@@ -107,39 +107,39 @@ namespace cli
             {
                 return "Syntax: allocate [pool blocks]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() == 1)
                 {
                     return cli.DoAllocate(std::string(), 0);
                 }
-                
+
                 if (argv.size() != 3)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 int blocks = 0;
                 if (!from_string(blocks, argv[2]))
                 {
                     return cli.SetError("Expected an integer (number of blocks).");
                 }
-                
+
                 if (blocks < 1)
                 {
                     return cli.SetError("Expected a positive integer (number of blocks).");
                 }
-                
+
                 return cli.DoAllocate(argv[1], blocks);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             AllocateCommand& operator=(const AllocateCommand&);
     };
-    
+
     class CaptureInputCommand : public cli::ParserCommand
     {
         public:
@@ -156,7 +156,7 @@ namespace cli
                     "capture-input [--query]\n"
                     "capture-input --close";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -168,10 +168,10 @@ namespace cli
                     {'q', "query", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::eCaptureInputMode mode = Cli::CAPTURE_INPUT_QUERY;
                 std::string pathname;
-                
+
                 bool autoflush = false;
                 for (;;)
                 {
@@ -179,12 +179,12 @@ namespace cli
                     {
                         return cli.SetError(opt.GetError());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'c':
@@ -202,16 +202,16 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 return cli.DoCaptureInput(mode, autoflush, mode == Cli::CAPTURE_INPUT_OPEN ? &pathname : 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             CaptureInputCommand& operator=(const CaptureInputCommand&);
     };
-    
+
     class CDCommand : public cli::ParserCommand
     {
         public:
@@ -225,7 +225,7 @@ namespace cli
             {
                 return "Syntax: cd [directory]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // Only takes one optional argument, the directory to change into
@@ -233,20 +233,20 @@ namespace cli
                 {
                     return cli.SetError("Only one argument (a directory) is allowed. Paths with spaces should be enclosed in quotes.");
                 }
-                
+
                 if (argv.size() > 1)
                 {
                     return cli.DoCD(&(argv[1]));
                 }
                 return cli.DoCD();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             CDCommand& operator=(const CDCommand&);
     };
-    
+
     class ChunkNameFormatCommand : public cli::ParserCommand
     {
         public:
@@ -262,7 +262,7 @@ namespace cli
                     "Syntax: chunk-name-format [-sl] -p [prefix]\n"
                     "chunk-name-format [-sl] -c [count]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -275,26 +275,26 @@ namespace cli
                     {'r', "rule",     OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool changeFormat = false;
                 bool countFlag = false;
                 int64_t count = -1;
                 bool patternFlag = false;
                 std::string pattern;
                 chunkNameFormats chunkFormat = ruleFormat;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'c':
@@ -328,21 +328,21 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoChunkNameFormat(changeFormat ? &chunkFormat : 0, countFlag ? &count : 0, patternFlag ? &pattern : 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ChunkNameFormatCommand& operator=(const ChunkNameFormatCommand&);
     };
-    
+
     class CLogCommand : public cli::ParserCommand
     {
         public:
@@ -356,7 +356,7 @@ namespace cli
             {
                 return "Syntax: clog -[Ae] filename\nclog -a string\nclog [-cdoq]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -371,9 +371,9 @@ namespace cli
                     {'q', "query",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::eLogMode mode = Cli::LOG_NEW;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -385,7 +385,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -405,7 +405,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 switch (mode)
                 {
                     case Cli::LOG_ADD:
@@ -416,14 +416,14 @@ namespace cli
                         {
                             return cli.SetError("Provide a string to add.");
                         }
-                        
+
                         // move to the first non-option arg
                         std::vector<std::string>::iterator iter = argv.begin();
                         for (int i = 0; i < (opt.GetArgument() - opt.GetNonOptionArguments()); ++i)
                         {
                             ++iter;
                         }
-                        
+
                         // combine all args
                         while (iter != argv.end())
                         {
@@ -433,33 +433,33 @@ namespace cli
                         }
                         return cli.DoCLog(mode, 0, &toAdd);
                     }
-                    
+
                     case Cli::LOG_NEW:
                         // no more than one argument, no filename == query
                         if (opt.GetNonOptionArguments() > 1)
                         {
                             return cli.SetError("Filename or nothing expected, enclose filename in quotes if there are spaces in the path.");
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoCLog(mode, &argv[1]);
                         }
                         break; // no args case handled below
-                        
+
                     case Cli::LOG_NEWAPPEND:
                         // exactly one argument
                         if (opt.GetNonOptionArguments() > 1)
                         {
                             return cli.SetError("Filename expected, enclose filename in quotes if there are spaces in the path.");
                         }
-                        
+
                         if (opt.GetNonOptionArguments() < 1)
                         {
                             return cli.SetError("Please provide a filename.");
                         }
                         return cli.DoCLog(mode, &argv[1]);
-                        
+
                     default:
                     case Cli::LOG_CLOSE:
                     case Cli::LOG_QUERY:
@@ -470,20 +470,20 @@ namespace cli
                         }
                         break; // no args case handled below
                 }
-                
+
                 // the no args case
                 return cli.DoCLog(mode);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             CLogCommand& operator=(const CLogCommand&);
     };
-    
+
     class CliExtensionMessageCommand : public cli::ParserCommand
     {
-    
+
         public:
             CliExtensionMessageCommand(cli::Cli& cli) : cli(cli), ParserCommand() {}
             virtual ~CliExtensionMessageCommand() {}
@@ -495,14 +495,14 @@ namespace cli
             {
                 return "Syntax: cli extension-name command [args]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() < 3)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 std::string concat_message(argv[1]);
                 for (std::vector<int>::size_type i = 2; i < argv.size(); ++i)
                 {
@@ -511,13 +511,13 @@ namespace cli
                 }
                 return cli.DoCLIMessage(concat_message);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             CliExtensionMessageCommand& operator=(const CliExtensionMessageCommand&);
     };
-    
+
     class CommandToFileCommand : public cli::ParserCommand
     {
         public:
@@ -531,7 +531,7 @@ namespace cli
             {
                 return "Syntax: command-to-file [-a] filename command [args]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // Not going to use normal option parsing in this case because I do not want to disturb the other command on the line
@@ -539,13 +539,13 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // Index of command in argv:  command-to-file filename command ...
                 // Unless append option is present, which is handled later.
                 int startOfCommand = 2;
                 Cli::eLogMode mode = Cli::LOG_NEW;
                 std::string filename = argv[1];
-                
+
                 // Parse out option.
                 for (int i = 1; i < 3; ++i)
                 {
@@ -574,50 +574,50 @@ namespace cli
                             unrecognized = true;
                         }
                     }
-                    
+
                     if (unrecognized)
                     {
                         return cli.SetError("Unrecognized option: " + arg);
                     }
-                    
+
                     if (append)
                     {
                         mode = Cli::LOG_NEWAPPEND;
-                        
+
                         // Index of command in argv:  command-to-file -a filename command ...
                         if (argv.size() < 4)
                         {
                             return cli.SetError(GetSyntax());
                         }
-                        
+
                         startOfCommand = 3;
-                        
+
                         // Re-set filename if necessary
                         if (i == 1)
                         {
                             filename = argv[2];
                         }
-                        
+
                         break;
                     }
                 }
-                
+
                 // Restructure argv
                 std::vector<std::string> newArgv;
                 for (std::vector<int>::size_type i = startOfCommand; i < argv.size(); ++i)
                 {
                     newArgv.push_back(argv[i]);
                 }
-                
+
                 return cli.DoCommandToFile(mode, filename, newArgv);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             CommandToFileCommand& operator=(const CommandToFileCommand&);
     };
-    
+
     class DebugCommand : public cli::ParserCommand
     {
         public:
@@ -631,25 +631,25 @@ namespace cli
             {
                 return "Syntax: debug [command] [arguments]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() == 1)
                 {
                     return cli.DoDebug();    // list all
                 }
-                
+
                 argv.erase(argv.begin());
-                
+
                 return cli.DoDebug(&argv);
-                
+
             }
         private:
             cli::Cli& cli;
             DebugCommand& operator=(const DebugCommand&);
     };
-    
-    
+
+
     class DefaultWMEDepthCommand : public cli::ParserCommand
     {
         public:
@@ -663,17 +663,17 @@ namespace cli
             {
                 return "Syntax: default-wme-depth [depth]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (query)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -683,16 +683,16 @@ namespace cli
                         return cli.SetError("Depth argument must be positive.");
                     }
                 }
-                
+
                 return cli.DoDefaultWMEDepth(n ? &n : 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             DefaultWMEDepthCommand& operator=(const DefaultWMEDepthCommand&);
     };
-    
+
     class DirsCommand : public cli::ParserCommand
     {
         public:
@@ -706,18 +706,18 @@ namespace cli
             {
                 return "Syntax: dirs";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoDirs();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             DirsCommand& operator=(const DirsCommand&);
     };
-    
+
     class EchoCommand : public cli::ParserCommand
     {
         public:
@@ -731,7 +731,7 @@ namespace cli
             {
                 return "Syntax: echo [--nonewline] [string]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -740,21 +740,21 @@ namespace cli
                     {'n', "no-newline", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool echoNewline(true);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'n':
@@ -762,22 +762,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // remove the -n arg
                 if (!echoNewline)
                 {
                     argv.erase(++argv.begin());
                 }
-                
+
                 return cli.DoEcho(argv, echoNewline);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             EchoCommand& operator=(const EchoCommand&);
     };
-    
+
     class EchoCommandsCommand : public cli::ParserCommand
     {
         public:
@@ -791,7 +791,7 @@ namespace cli
             {
                 return "Syntax: echo-commands [-yn]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -801,10 +801,10 @@ namespace cli
                     {'n', "no",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool echoCommands = true ;
                 bool onlyGetValue = true ;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -816,7 +816,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'y':
@@ -829,21 +829,21 @@ namespace cli
                             break ;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError("Format is 'echo-commands [--yes | --no]") ;
                 }
-                
+
                 return cli.DoEchoCommands(onlyGetValue, echoCommands);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             EchoCommandsCommand& operator=(const EchoCommandsCommand&);
     };
-    
+
     class EditProductionCommand : public cli::ParserCommand
     {
         public:
@@ -857,23 +857,23 @@ namespace cli
             {
                 return "Syntax: edit-production production_name";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() != 2)
                 {
                     return cli.SetError("Need to include the name of the production to edit.");
                 }
-                
+
                 return cli.DoEditProduction(argv[1]);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             EditProductionCommand& operator=(const EditProductionCommand&);
     };
-    
+
     class EpMemCommand : public cli::ParserCommand
     {
         public:
@@ -887,7 +887,7 @@ namespace cli
             {
                 return "Syntax: epmem [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -908,35 +908,35 @@ namespace cli
                     {'v', "viz",          OPTARG_NONE},
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("Invalid parameters.");
                     }
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 0:
                     default:
                         // no options
                         break;
-                        
+
                     case 'i':
                     case 'e':
                     case 'd':
@@ -947,19 +947,19 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoEpMem(option);
                     }
-                    
+
                     case 'b':
                         // case: backup requires one non-option argument
                         if (!opt.CheckNumNonOptArgs(1, 1))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoEpMem(option, &(argv[2]));
-                        
+
                     case 'g':
                         // case: get requires one non-option argument
                     {
@@ -967,10 +967,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoEpMem(option, &(argv[2]));
                     }
-                    
+
                     case 'p':
                         // case: print takes one non-option argument
                     {
@@ -978,18 +978,18 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         std::string temp_str(argv[2]);
                         epmem_time_id memory_id;
-                        
+
                         if (!from_string(memory_id, temp_str))
                         {
                             return cli.SetError("Invalid epmem time tag.");
                         }
-                        
+
                         return cli.DoEpMem(option, 0, 0, memory_id);
                     }
-                    
+
                     case 's':
                         // case: set requires two non-option arguments
                     {
@@ -997,10 +997,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoEpMem('s', &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 'S':
                         // case: stat can do zero or one non-option arguments
                     {
@@ -1008,15 +1008,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoEpMem(option);
                         }
-                        
+
                         return cli.DoEpMem(option, &(argv[2]));
                     }
-                    
+
                     case 't':
                         // case: timer can do zero or one non-option arguments
                     {
@@ -1024,15 +1024,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoEpMem(option);
                         }
-                        
+
                         return cli.DoEpMem(option, &(argv[2]));
                     }
-                    
+
                     case 'v':
                         // case: viz takes one non-option argument
                     {
@@ -1040,35 +1040,35 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         std::string temp_str(argv[2]);
                         epmem_time_id memory_id;
-                        
+
                         if (!from_string(memory_id, temp_str))
                         {
                             return cli.SetError("Invalid epmem time tag.");
                         }
-                        
+
                         return cli.DoEpMem(option, 0, 0, memory_id);
                     }
                 }
-                
+
                 // bad: no option, but more than one argument
                 if (argv.size() > 1)
                 {
                     return cli.SetError("Too many arguments, check syntax.");
                 }
-                
+
                 // case: nothing = full configuration information
                 return cli.DoEpMem();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             EpMemCommand& operator=(const EpMemCommand&);
     };
-    
+
     class ExciseCommand : public cli::ParserCommand
     {
         public:
@@ -1082,7 +1082,7 @@ namespace cli
             {
                 return "Syntax: excise production_name\nexcise options";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1097,9 +1097,9 @@ namespace cli
                     {'u', "user",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::ExciseBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -1111,7 +1111,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -1137,7 +1137,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // If there are options, no additional argument.
                 if (options.any())
                 {
@@ -1147,7 +1147,7 @@ namespace cli
                     }
                     return cli.DoExcise(options);
                 }
-                
+
                 // If there are no options, there must be only one production name argument
                 if (opt.GetNonOptionArguments() < 1)
                 {
@@ -1157,17 +1157,17 @@ namespace cli
                 {
                     return cli.SetError("Only one production name allowed, call excise multiple times to excise more than one specific production.");
                 }
-                
+
                 // Pass the production to the cli.DoExcise function
                 return cli.DoExcise(options, &(argv[opt.GetArgument() - opt.GetNonOptionArguments()]));
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ExciseCommand& operator=(const ExciseCommand&);
     };
-    
+
     class ExplainBacktracesCommand : public cli::ParserCommand
     {
         public:
@@ -1181,7 +1181,7 @@ namespace cli
             {
                 return "Syntax: explain-backtraces [options] [prod_name]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1191,9 +1191,9 @@ namespace cli
                     {'f', "full",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 int condition = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -1205,13 +1205,13 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'f':
                             condition = -1;
                             break;
-                            
+
                         case 'c':
                             if (!from_string(condition, opt.GetOptionArgument()) || (condition <= 0))
                             {
@@ -1220,36 +1220,36 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // never more than one arg
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // we need a production if full or condition given
                 if (condition)
                     if (opt.GetNonOptionArguments() < 1)
                     {
                         return cli.SetError("Production name required for that option.");
                     }
-                    
+
                 // we have a production
                 if (opt.GetNonOptionArguments() == 1)
                 {
                     return cli.DoExplainBacktraces(&argv[opt.GetArgument() - opt.GetNonOptionArguments()], condition);
                 }
-                
+
                 // query
                 return cli.DoExplainBacktraces();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ExplainBacktracesCommand& operator=(const ExplainBacktracesCommand&);
     };
-    
+
     class FiringCountsCommand : public cli::ParserCommand
     {
         public:
@@ -1263,21 +1263,21 @@ namespace cli
             {
                 return "Syntax: firing-counts [n]\nfiring-counts production_name";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // The number to list defaults to -1 (list all)
                 int numberToList = -1;
-                
+
                 // Production defaults to no production
                 std::string* pProduction = 0;
-                
+
                 // no more than 1 arg
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (argv.size() == 2)
                 {
                     // one argument, figure out if it is a non-negative integer or a production
@@ -1287,26 +1287,26 @@ namespace cli
                         {
                             return cli.SetError("Expected non-negative integer (count).");
                         }
-                        
+
                     }
                     else
                     {
                         numberToList = -1;
-                        
+
                         // non-integer argument, hopfully a production
                         pProduction = &(argv[1]);
                     }
                 }
-                
+
                 return cli.DoFiringCounts(numberToList, pProduction);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             FiringCountsCommand& operator=(const FiringCountsCommand&);
     };
-    
+
     class GDSPrintCommand : public cli::ParserCommand
     {
         public:
@@ -1320,18 +1320,18 @@ namespace cli
             {
                 return "Syntax: gds-print";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoGDSPrint();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             GDSPrintCommand& operator=(const GDSPrintCommand&);
     };
-    
+
     class GPCommand : public cli::ParserCommand
     {
         public:
@@ -1345,7 +1345,7 @@ namespace cli
             {
                 return "Syntax: gp { production_body }";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // One argument
@@ -1357,16 +1357,16 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoGP(argv[1]);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             GPCommand& operator=(const GPCommand&);
     };
-    
+
     class GPMaxCommand : public cli::ParserCommand
     {
         public:
@@ -1380,17 +1380,17 @@ namespace cli
             {
                 return "Syntax: gp-max [value]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = -1;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -1400,16 +1400,16 @@ namespace cli
                         return cli.SetError("Value must be non-negative.");
                     }
                 }
-                
+
                 return cli.DoGPMax(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             GPMaxCommand& operator=(const GPMaxCommand&);
     };
-    
+
     class HelpCommand : public cli::ParserCommand
     {
         public:
@@ -1423,18 +1423,18 @@ namespace cli
             {
                 return "Syntax: help [command]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 return cli.DoHelp(argv);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             HelpCommand& operator=(const HelpCommand&);
     };
-    
+
     class IndifferentSelectionCommand : public cli::ParserCommand
     {
         public:
@@ -1455,7 +1455,7 @@ namespace cli
                     "indifferent-selection [-r] parameter reduction_policy [reduction_rate]\n"
                     "indifferent-selection [-a] [setting]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1468,52 +1468,52 @@ namespace cli
                     {'l', "last",                OPTARG_NONE},
                     //{'u', "random-uniform",        OPTARG_NONE},
                     {'x', "softmax",            OPTARG_NONE},
-                    
+
                     // selection parameters
                     {'e', "epsilon",            OPTARG_NONE},
                     {'t', "temperature",        OPTARG_NONE},
-                    
+
                     // auto-reduction control
                     {'a', "auto-reduce",        OPTARG_NONE},
-                    
+
                     // selection parameter reduction
                     {'p', "reduction-policy",    OPTARG_NONE},
                     {'r', "reduction-rate",        OPTARG_NONE},
-                    
+
                     // stats
                     {'s', "stats",                OPTARG_NONE},
-                    
+
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("indifferent-selection takes only one option at a time.");
                     }
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 0:
                     default:
                         // no options
                         break;
-                        
+
                     case 'b':
                     case 'g':
                     case 'f':
@@ -1525,7 +1525,7 @@ namespace cli
                             return cli.SetError(opt.GetError().c_str());
                         }
                         return cli.DoIndifferentSelection(option);
-                        
+
                     case 'e':
                     case 't':
                         // case: selection parameter can do zero or one non-option arguments
@@ -1533,82 +1533,82 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoIndifferentSelection(option);
                         }
-                        
+
                         return cli.DoIndifferentSelection(option, &(argv[2]));
-                        
+
                     case 'a':
                         // case: auto reduction control can do zero or one non-option arguments
                         if (!opt.CheckNumNonOptArgs(0, 1))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoIndifferentSelection(option);
                         }
-                        
+
                         return cli.DoIndifferentSelection(option, &(argv[2]));
-                        
+
                     case 'p':
                         // case: reduction policy requires one or two non-option arguments
                         if (!opt.CheckNumNonOptArgs(1, 2))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoIndifferentSelection(option, &(argv[2]));
                         }
-                        
+
                         return cli.DoIndifferentSelection(option, &(argv[2]), &(argv[3]));
-                        
+
                     case 'r':
                         // case: reduction policy rate requires two or three arguments
                         if (!opt.CheckNumNonOptArgs(2, 3))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 2)
                         {
                             return cli.DoIndifferentSelection(option, &(argv[2]), &(argv[3]));
                         }
-                        
+
                         return cli.DoIndifferentSelection(option, &(argv[2]), &(argv[3]), &(argv[4]));
-                        
+
                     case 's':
                         // case: stats takes no parameters
                         if (!opt.CheckNumNonOptArgs(0, 0))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoIndifferentSelection(option);
                 }
-                
+
                 // bad: no option, but more than one argument
                 if (argv.size() > 1)
                 {
                     return cli.SetError("Too many args.");
                 }
-                
+
                 // case: nothing = full configuration information
                 return cli.DoIndifferentSelection();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             IndifferentSelectionCommand& operator=(const IndifferentSelectionCommand&);
     };
-    
+
     class InitSoarCommand : public cli::ParserCommand
     {
         public:
@@ -1622,18 +1622,18 @@ namespace cli
             {
                 return "Syntax: init-soar";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoInitSoar();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             InitSoarCommand& operator=(const InitSoarCommand&);
     };
-    
+
     class InternalSymbolsCommand : public cli::ParserCommand
     {
         public:
@@ -1647,18 +1647,18 @@ namespace cli
             {
                 return "Syntax: internal-symbols";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoInternalSymbols();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             InternalSymbolsCommand& operator=(const InternalSymbolsCommand&);
     };
-    
+
     class LearnCommand : public cli::ParserCommand
     {
         public:
@@ -1672,7 +1672,7 @@ namespace cli
             {
                 return "Syntax: learn [-abdeElonNpP]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1693,9 +1693,9 @@ namespace cli
                     {'P', "no-desirability-prefs", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::LearnBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -1707,7 +1707,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -1745,22 +1745,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // No non-option arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoLearn(options);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             LearnCommand& operator=(const LearnCommand&);
     };
-    
+
     class LoadLibraryCommand : public cli::ParserCommand
     {
         public:
@@ -1774,16 +1774,16 @@ namespace cli
             {
                 return "Syntax: load-library [library_name] [arguments]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // command-name library-name [library-args ...]
-                
+
                 if (argv.size() < 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // strip the command name, combine the rest
                 std::string libraryCommand(argv[1]);
                 for (std::string::size_type i = 2; i < argv.size(); ++i)
@@ -1791,16 +1791,16 @@ namespace cli
                     libraryCommand += " ";
                     libraryCommand += argv[i];
                 }
-                
+
                 return cli.DoLoadLibrary(libraryCommand);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             LoadLibraryCommand& operator=(const LoadLibraryCommand&);
     };
-    
+
     class LSCommand : public cli::ParserCommand
     {
         public:
@@ -1814,7 +1814,7 @@ namespace cli
             {
                 return "Syntax: ls";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // No arguments
@@ -1824,13 +1824,13 @@ namespace cli
                 }
                 return cli.DoLS();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             LSCommand& operator=(const LSCommand&);
     };
-    
+
     class MatchesCommand : public cli::ParserCommand
     {
         public:
@@ -1844,7 +1844,7 @@ namespace cli
             {
                 return "Syntax: matches [options] production_name\nmatches [options] -[a|r]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1858,10 +1858,10 @@ namespace cli
                     {'w', "wmes",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::eWMEDetail detail = Cli::WME_DETAIL_NONE;
                 Cli::eMatchesMode mode = Cli::MATCHES_ASSERTIONS_RETRACTIONS;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -1873,7 +1873,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'n':
@@ -1894,13 +1894,13 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // Max one additional argument and it is a production
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (opt.GetNonOptionArguments() == 1)
                 {
                     if (mode != Cli::MATCHES_ASSERTIONS_RETRACTIONS)
@@ -1909,16 +1909,16 @@ namespace cli
                     }
                     return cli.DoMatches(Cli::MATCHES_PRODUCTION, detail, &argv[opt.GetArgument() - opt.GetNonOptionArguments()]);
                 }
-                
+
                 return cli.DoMatches(mode, detail);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MatchesCommand& operator=(const MatchesCommand&);
     };
-    
+
     class MaxChunksCommand : public cli::ParserCommand
     {
         public:
@@ -1932,17 +1932,17 @@ namespace cli
             {
                 return "Syntax: max-chunks [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -1952,16 +1952,16 @@ namespace cli
                         return cli.SetError("Expected positive integer.");
                     }
                 }
-                
+
                 return cli.DoMaxChunks(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxChunksCommand& operator=(const MaxChunksCommand&);
     };
-    
+
     class MaxDCTimeCommand : public cli::ParserCommand
     {
         public:
@@ -1975,7 +1975,7 @@ namespace cli
             {
                 return "Syntax: max-dc-time [--seconds] [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -1986,12 +1986,12 @@ namespace cli
                     {'o', "off", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool seconds = false;
-                
+
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2003,7 +2003,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 's':
@@ -2015,47 +2015,47 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (opt.GetNonOptionArguments() == 1)
                 {
                     int index = opt.GetArgument() - opt.GetNonOptionArguments();
-                    
+
                     if (seconds)
                     {
                         double nsec = 0;
-                        
+
                         if (!from_string(nsec, argv[index]))
                         {
                             return cli.SetError(GetSyntax());
                         }
-                        
+
                         n = static_cast<int>(nsec * 1000000);
                     }
                     else
                     {
                         from_string(n, argv[index]);
                     }
-                    
+
                     if (n <= 0)
                     {
                         return cli.SetError("Expected positive value.");
                     }
                 }
-                
+
                 return cli.DoMaxDCTime(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxDCTimeCommand& operator=(const MaxDCTimeCommand&);
     };
-    
+
     class MaxElaborationsCommand : public cli::ParserCommand
     {
         public:
@@ -2069,17 +2069,17 @@ namespace cli
             {
                 return "Syntax: max-elaborations [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -2089,16 +2089,16 @@ namespace cli
                         return cli.SetError("Expected positive integer.");
                     }
                 }
-                
+
                 return cli.DoMaxElaborations(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxElaborationsCommand& operator=(const MaxElaborationsCommand&);
     };
-    
+
     class MaxGoalDepthCommand : public cli::ParserCommand
     {
         public:
@@ -2112,17 +2112,17 @@ namespace cli
             {
                 return "Syntax: max-goal-depth [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -2132,16 +2132,16 @@ namespace cli
                         return cli.SetError("Expected positive integer.");
                     }
                 }
-                
+
                 return cli.DoMaxGoalDepth(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxGoalDepthCommand& operator=(const MaxGoalDepthCommand&);
     };
-    
+
     class MaxMemoryUsageCommand : public cli::ParserCommand
     {
         public:
@@ -2155,17 +2155,17 @@ namespace cli
             {
                 return "Syntax: max-memory-usage [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -2175,16 +2175,16 @@ namespace cli
                         return cli.SetError("Expected positive integer.");
                     }
                 }
-                
+
                 return cli.DoMaxMemoryUsage(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxMemoryUsageCommand& operator=(const MaxMemoryUsageCommand&);
     };
-    
+
     class MaxNilOutputCyclesCommand : public cli::ParserCommand
     {
         public:
@@ -2198,17 +2198,17 @@ namespace cli
             {
                 return "Syntax: max-nil-output-cycles [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // n defaults to 0 (print current value)
                 int n = 0;
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // one argument, figure out if it is a positive integer
                 if (argv.size() == 2)
                 {
@@ -2218,16 +2218,16 @@ namespace cli
                         return cli.SetError("Expected positive integer.");
                     }
                 }
-                
+
                 return cli.DoMaxNilOutputCycles(n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MaxNilOutputCyclesCommand& operator=(const MaxNilOutputCyclesCommand&);
     };
-    
+
     class MemoriesCommand : public cli::ParserCommand
     {
         public:
@@ -2241,7 +2241,7 @@ namespace cli
             {
                 return "Syntax: memories [options] [number]\nmemories production_name";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2254,9 +2254,9 @@ namespace cli
                     {'u', "user",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::MemoriesBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2268,7 +2268,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'c':
@@ -2288,13 +2288,13 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // Max one additional argument
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // It is either a production or a number
                 int n = 0;
                 if (opt.GetNonOptionArguments() == 1)
@@ -2318,23 +2318,23 @@ namespace cli
                         return cli.DoMemories(options, 0, &argv[optind]);
                     }
                 }
-                
+
                 // Default to all types when no production and no type specified
                 if (options.none())
                 {
                     options.flip();
                 }
-                
+
                 // handle production/number cases
                 return cli.DoMemories(options, n);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MemoriesCommand& operator=(const MemoriesCommand&);
     };
-    
+
     class MultiAttributesCommand : public cli::ParserCommand
     {
         public:
@@ -2348,7 +2348,7 @@ namespace cli
             {
                 return "Syntax: multi-attributes [symbol [n]]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // No more than three arguments
@@ -2356,7 +2356,7 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 int n = 0;
                 // If we have 3 arguments, third one is an integer
                 if (argv.size() > 2)
@@ -2366,22 +2366,22 @@ namespace cli
                         return cli.SetError("Expected non-negative integer.");
                     }
                 }
-                
+
                 // If we have two arguments, second arg is an attribute/identifer/whatever
                 if (argv.size() > 1)
                 {
                     return cli.DoMultiAttributes(&argv[1], n);
                 }
-                
+
                 return cli.DoMultiAttributes();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             MultiAttributesCommand& operator=(const MultiAttributesCommand&);
     };
-    
+
     class NumericIndifferentModeCommand : public cli::ParserCommand
     {
         public:
@@ -2395,7 +2395,7 @@ namespace cli
             {
                 return "Syntax: numeric-indifferent-mode [-as]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2406,10 +2406,10 @@ namespace cli
                     {'s', "sum",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 ni_mode mode = NUMERIC_INDIFFERENT_MODE_AVG;
                 bool query = true;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2421,7 +2421,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -2434,22 +2434,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // No additional arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoNumericIndifferentMode(query, mode);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             NumericIndifferentModeCommand& operator=(const NumericIndifferentModeCommand&);
     };
-    
+
     class OSupportModeCommand : public cli::ParserCommand
     {
         public:
@@ -2463,14 +2463,14 @@ namespace cli
             {
                 return "Syntax: o-support-mode [n]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 int mode = -1;
                 if (argv.size() == 2)
                 {
@@ -2484,16 +2484,16 @@ namespace cli
                         return cli.SetError("Expected an integer 0, 2, 3, or 4.");
                     }
                 }
-                
+
                 return cli.DoOSupportMode(mode);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             OSupportModeCommand& operator=(const OSupportModeCommand&);
     };
-    
+
     class PbreakCommand : public cli::ParserCommand
     {
         public:
@@ -2507,7 +2507,7 @@ namespace cli
             {
                 return "Syntax: pbreak [-cps] production_name";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2518,28 +2518,28 @@ namespace cli
                     {'s', "set",   OPTARG_NONE},
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("pbreak takes only one option at a time.");
                     }
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 'c':
@@ -2548,19 +2548,19 @@ namespace cli
                         {
                             return cli.SetError("pbreak --set/--clear takes exactly one argument.");
                         }
-                        
+
                         // case: clear the interrupt flag on the production
                         return cli.DoPbreak(option, argv[2]);
-                        
+
                     case 'p':
                         if (argv.size() != 2)
                         {
                             return cli.SetError("pbreak --print takes no arguments.");
                         }
-                        
+
                         // case: set the interrupt flag on the production
                         return cli.DoPbreak('p', "");
-                        
+
                     default:
                         if (argv.size() == 1)
                         {
@@ -2575,17 +2575,17 @@ namespace cli
                             return cli.SetError("pbreak used incorrectly.");
                         }
                 }
-                
+
                 // bad: no option, but more than one argument
                 return cli.SetError("pbreak takes exactly one argument.");
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PbreakCommand& operator=(const PbreakCommand&);
     };
-    
+
     class PopDCommand : public cli::ParserCommand
     {
         public:
@@ -2599,7 +2599,7 @@ namespace cli
             {
                 return "Syntax: popd";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // No arguments
@@ -2609,13 +2609,13 @@ namespace cli
                 }
                 return cli.DoPopD();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PopDCommand& operator=(const PopDCommand&);
     };
-    
+
     class PortCommand : public cli::ParserCommand
     {
         public:
@@ -2629,18 +2629,18 @@ namespace cli
             {
                 return "Syntax: port";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoPort();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PortCommand& operator=(const PortCommand&);
     };
-    
+
     class PredictCommand : public cli::ParserCommand
     {
         public:
@@ -2654,7 +2654,7 @@ namespace cli
             {
                 return "Syntax: predict";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // No arguments to predict next operator
@@ -2662,16 +2662,16 @@ namespace cli
                 {
                     return cli.SetError("predict takes no arguments.");
                 }
-                
+
                 return cli.DoPredict();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PredictCommand& operator=(const PredictCommand&);
     };
-    
+
     class PreferencesCommand : public cli::ParserCommand
     {
         public:
@@ -2685,7 +2685,7 @@ namespace cli
             {
                 return "Syntax: preferences [options] [identifier [attribute]]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2702,10 +2702,10 @@ namespace cli
                     {'o', "object",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::ePreferencesDetail detail = Cli::PREFERENCES_ONLY;
                 bool object = false;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2717,7 +2717,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case '0':
@@ -2736,20 +2736,20 @@ namespace cli
                         case 'w':
                             detail = Cli::PREFERENCES_WMES;
                             break;
-                            
+
                         case 'o':
                         case 'O':
                             object = true;
                             break;
                     }
                 }
-                
+
                 // Up to two non-option arguments allowed, id/attribute
                 if (opt.GetNonOptionArguments() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 int optind = opt.GetArgument() - opt.GetNonOptionArguments();
                 if (opt.GetNonOptionArguments() == 2)
                 {
@@ -2761,16 +2761,16 @@ namespace cli
                     // id
                     return cli.DoPreferences(detail, object, &argv[optind]);
                 }
-                
+
                 return cli.DoPreferences(detail, object);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PreferencesCommand& operator=(const PreferencesCommand&);
     };
-    
+
     class PrintCommand : public cli::ParserCommand
     {
         public:
@@ -2784,7 +2784,7 @@ namespace cli
             {
                 return "Syntax: print [options] [production_name]\nprint [options] identifier|timetag|pattern";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2810,10 +2810,10 @@ namespace cli
                     {'v', "varprint",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 int depth = -1;
                 Cli::PrintBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2825,7 +2825,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -2888,7 +2888,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // STATES and OPERATORS are sub-options of STACK
                 if (options.test(Cli::PRINT_OPERATORS) || options.test(Cli::PRINT_STATES))
                 {
@@ -2897,7 +2897,7 @@ namespace cli
                         return cli.SetError("Options --operators (-o) and --states (-S) are only valid when printing the stack.");
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() == 0)
                 {
                     // d and t options require an argument
@@ -2907,7 +2907,7 @@ namespace cli
                     }
                     return cli.DoPrint(options, depth);
                 }
-                
+
                 // the acDjus options don't allow an argument
                 if (options.test(Cli::PRINT_ALL)
                         || options.test(Cli::PRINT_CHUNKS)
@@ -2924,7 +2924,7 @@ namespace cli
                 {
                     return cli.SetError("No depth/tree flags allowed when printing exact.");
                 }
-                
+
                 std::string arg;
                 for (int i = opt.GetArgument() - opt.GetNonOptionArguments(); i < argv.size(); ++i)
                 {
@@ -2936,13 +2936,13 @@ namespace cli
                 }
                 return cli.DoPrint(options, depth, &arg);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PrintCommand& operator=(const PrintCommand&);
     };
-    
+
     class ProductionFindCommand : public cli::ParserCommand
     {
         public:
@@ -2956,7 +2956,7 @@ namespace cli
             {
                 return "Syntax: production-find [-lrs[n|c]] pattern";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -2969,9 +2969,9 @@ namespace cli
                     {'s', "show-bindings",    OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::ProductionFindBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -2983,7 +2983,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'c':
@@ -3005,17 +3005,17 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (!opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (options.none())
                 {
                     options.set(Cli::PRODUCTION_FIND_INCLUDE_LHS);
                 }
-                
+
                 std::string pattern;
                 for (unsigned i = opt.GetArgument() - opt.GetNonOptionArguments(); i < argv.size(); ++i)
                 {
@@ -3023,16 +3023,16 @@ namespace cli
                     pattern += ' ';
                 }
                 pattern = pattern.substr(0, pattern.length() - 1);
-                
+
                 return cli.DoProductionFind(options, pattern);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ProductionFindCommand& operator=(const ProductionFindCommand&);
     };
-    
+
     class PushDCommand : public cli::ParserCommand
     {
         public:
@@ -3046,7 +3046,7 @@ namespace cli
             {
                 return "Syntax: pushd directory";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // Only takes one argument, the directory to change into
@@ -3060,13 +3060,13 @@ namespace cli
                 }
                 return cli.DoPushD(argv[1]);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PushDCommand& operator=(const PushDCommand&);
     };
-    
+
     class PWatchCommand : public cli::ParserCommand
     {
         public:
@@ -3080,7 +3080,7 @@ namespace cli
             {
                 return "Syntax: pwatch [-d|e] [production name]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3092,10 +3092,10 @@ namespace cli
                     {'e', "on",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool setting = true;
                 bool query = true;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3107,7 +3107,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -3123,20 +3123,20 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (opt.GetNonOptionArguments() == 1)
                 {
                     return cli.DoPWatch(false, &argv[opt.GetArgument() - opt.GetNonOptionArguments()], setting);
                 }
                 return cli.DoPWatch(query, 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PWatchCommand& operator=(const PWatchCommand&);
     };
-    
+
     class PWDCommand : public cli::ParserCommand
     {
         public:
@@ -3150,7 +3150,7 @@ namespace cli
             {
                 return "Syntax: pwd";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // No arguments to print working directory
@@ -3160,13 +3160,13 @@ namespace cli
                 }
                 return cli.DoPWD();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             PWDCommand& operator=(const PWDCommand&);
     };
-    
+
     class RandCommand : public cli::ParserCommand
     {
         public:
@@ -3180,7 +3180,7 @@ namespace cli
             {
                 return "Syntax: rand\nrand n\nrand --integer\nrand --integer n";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3189,9 +3189,9 @@ namespace cli
                     {'i', "integer", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool integer(false);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3203,7 +3203,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'i':
@@ -3211,7 +3211,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
@@ -3221,16 +3221,16 @@ namespace cli
                     unsigned optind = opt.GetArgument() - opt.GetNonOptionArguments();
                     return cli.DoRand(integer, &(argv[optind]));
                 }
-                
+
                 return cli.DoRand(integer, 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             RandCommand& operator=(const RandCommand&);
     };
-    
+
     class RemoveWMECommand : public cli::ParserCommand
     {
         public:
@@ -3244,7 +3244,7 @@ namespace cli
             {
                 return "Syntax: remove-wme timetag";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // Exactly one argument
@@ -3256,23 +3256,23 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 uint64_t timetag = 0;
                 from_string(timetag, argv[1]);
                 if (!timetag)
                 {
                     return cli.SetError("Timetag must be positive.");
                 }
-                
+
                 return cli.DoRemoveWME(timetag);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             RemoveWMECommand& operator=(const RemoveWMECommand&);
     };
-    
+
     class ReplayInputCommand : public cli::ParserCommand
     {
         public:
@@ -3286,7 +3286,7 @@ namespace cli
             {
                 return "Syntax: replay-input --open filename\nreplay-input [--query]\nreplay-input --close";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3297,10 +3297,10 @@ namespace cli
                     {'q', "query", OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::eReplayInputMode mode = Cli::REPLAY_INPUT_QUERY;
                 std::string pathname;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3312,7 +3312,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'c':
@@ -3327,16 +3327,16 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 return cli.DoReplayInput(mode, mode == Cli::REPLAY_INPUT_OPEN ? &pathname : 0);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ReplayInputCommand& operator=(const ReplayInputCommand&);
     };
-    
+
     class ReteNetCommand : public cli::ParserCommand
     {
         public:
@@ -3351,7 +3351,7 @@ namespace cli
                 return
                     "Syntax: rete-net -s|l filename";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3362,11 +3362,11 @@ namespace cli
                     {'s', "save",        OPTARG_REQUIRED},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool save = false;
                 bool load = false;
                 std::string filename;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3378,7 +3378,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'l':
@@ -3394,7 +3394,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // Must have a save or load operation
                 if (!save && !load)
                 {
@@ -3404,16 +3404,16 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoReteNet(save, filename);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             ReteNetCommand& operator=(const ReteNetCommand&);
     };
-    
+
     class RLCommand : public cli::ParserCommand
     {
         public:
@@ -3427,7 +3427,7 @@ namespace cli
             {
                 return "Syntax: rl [options parameter|statstic]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3439,35 +3439,35 @@ namespace cli
                     {'S', "stats",    OPTARG_NONE},
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("rl takes only one option at a time.");
                     }
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 0:
                     default:
                         // no options
                         break;
-                        
+
                     case 'g':
                         // case: get requires one non-option argument
                     {
@@ -3475,10 +3475,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoRL(option, &(argv[2]));
                     }
-                    
+
                     case 's':
                         // case: set requires two non-option arguments
                     {
@@ -3486,10 +3486,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoRL(option, &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 't':
                         // case: trace can do 0-2 non-option arguments
                     {
@@ -3497,7 +3497,7 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoRL(option);
@@ -3506,10 +3506,10 @@ namespace cli
                         {
                             return cli.DoRL(option, &(argv[2]));
                         }
-                        
+
                         return cli.DoRL(option, &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 'S':
                         // case: stat and trace can do zero or one non-option arguments
                     {
@@ -3517,32 +3517,32 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoRL(option);
                         }
-                        
+
                         return cli.DoRL(option, &(argv[2]));
                     }
                 }
-                
+
                 // bad: no option, but more than one argument
                 if (argv.size() > 1)
                 {
                     return cli.SetError("Invalid syntax.");
                 }
-                
+
                 // case: nothing = full configuration information
                 return cli.DoRL();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             RLCommand& operator=(const RLCommand&);
     };
-    
+
     class RunCommand : public cli::ParserCommand
     {
         public:
@@ -3556,7 +3556,7 @@ namespace cli
             {
                 return "Syntax: run  [-f|count]\nrun -[d|e|o|p][s][un][g] [f|count]\nrun -[d|e|o|p][un] count [-i e|p|d|o]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3573,10 +3573,10 @@ namespace cli
                     {'u', "update",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::RunBitset options(0);
                 Cli::eRunInterleaveMode interleaveMode = Cli::RUN_INTERLEAVE_DEFAULT;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3588,7 +3588,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -3625,16 +3625,16 @@ namespace cli
                             break ;
                     }
                 }
-                
+
                 // Only one non-option argument allowed, count
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 // Decide if we explicitly indicated how to run
                 bool specifiedType = (options.test(Cli::RUN_ELABORATION) || options.test(Cli::RUN_DECISION) || options.test(Cli::RUN_PHASE) || options.test(Cli::RUN_OUTPUT)) ;
-                
+
                 // Count defaults to -1
                 int count = -1;
                 if (opt.GetNonOptionArguments() == 1)
@@ -3650,13 +3650,13 @@ namespace cli
                         return cli.SetError("Count must be positive.");
                     }
                 }
-                
+
                 return cli.DoRun(options, count, interleaveMode);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             Cli::eRunInterleaveMode ParseRunInterleaveOptarg(cli::Options& opt)
             {
                 if (opt.GetOptionArgument() == "d")
@@ -3675,14 +3675,14 @@ namespace cli
                 {
                     return Cli::RUN_INTERLEAVE_PHASE;
                 }
-                
+
                 cli.SetError("Invalid interleave switch: " + opt.GetOptionArgument());
                 return Cli::RUN_INTERLEAVE_DEFAULT;
             }
-            
+
             RunCommand& operator=(const RunCommand&);
     };
-    
+
     class SaveBacktracesCommand : public cli::ParserCommand
     {
         public:
@@ -3696,7 +3696,7 @@ namespace cli
             {
                 return "Syntax: save-backtraces [-ed]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3708,10 +3708,10 @@ namespace cli
                     {'e', "on",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool setting = true;
                 bool query = true;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3723,7 +3723,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -3742,13 +3742,13 @@ namespace cli
                 }
                 return cli.DoSaveBacktraces(query ? 0 : &setting);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SaveBacktracesCommand& operator=(const SaveBacktracesCommand&);
     };
-    
+
     class SelectCommand : public cli::ParserCommand
     {
         public:
@@ -3762,7 +3762,7 @@ namespace cli
             {
                 return "Syntax: select id";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // At most one argument to select the next operator
@@ -3770,21 +3770,21 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 if (argv.size() == 2)
                 {
                     return cli.DoSelect(&(argv[1]));
                 }
-                
+
                 return cli.DoSelect();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SelectCommand& operator=(const SelectCommand&);
     };
-    
+
     class SetStopPhaseCommand : public cli::ParserCommand
     {
         public:
@@ -3798,7 +3798,7 @@ namespace cli
             {
                 return "Syntax: set-stop-phase -[ABadiop]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3813,11 +3813,11 @@ namespace cli
                     {'o', "output",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 sml::smlPhase phase = sml::sml_INPUT_PHASE ;
                 int countPhaseArgs = 0 ;
                 bool before = true ;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -3829,7 +3829,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'B':
@@ -3860,21 +3860,21 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() || countPhaseArgs > 1)
                 {
                     return cli.SetError("Format is 'set-stop-phase [--Before | --After] <phase>' where <phase> is --input | --proposal | --decision | --apply | --output\ne.g. set-stop-phase --before --input") ;
                 }
-                
+
                 return cli.DoSetStopPhase(countPhaseArgs == 1, before, phase);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SetStopPhaseCommand& operator=(const SetStopPhaseCommand&);
     };
-    
+
     class SMemCommand : public cli::ParserCommand
     {
         public:
@@ -3888,7 +3888,7 @@ namespace cli
             {
                 return "Syntax: smem [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -3912,54 +3912,54 @@ namespace cli
                     {'v', "viz",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("smem takes only one option at a time.");
                     }
-                    
+
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 0:
                     default:
                         // no options
                         break;
-                        
+
                     case 'a':
                         // case: add requires one non-option argument
                         if (!opt.CheckNumNonOptArgs(1, 1))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]));
-                        
+
                     case 'b':
                         // case: backup requires one non-option argument
                         if (!opt.CheckNumNonOptArgs(1, 1))
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]));
-                        
+
                     case 'g':
                     {
                         // case: get requires one non-option argument
@@ -3967,10 +3967,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]));
                     }
-                    
+
                     case 'h':
                     {
                         // case: history only accepts 1 non-option argument
@@ -3978,10 +3978,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), 0);
                     }
-                    
+
                     case 'i':
                     case 'e':
                     case 'd':
@@ -3990,9 +3990,9 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option);
-                        
+
                     case 'p':
                     {
                         // case: print does zero or 1/2 non-option arguments
@@ -4000,20 +4000,20 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoSMem(option);
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoSMem(option, &(argv[2]), 0);
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 'q':
                     {
                         // case: query requires one non-option argument, but can have a depth argument
@@ -4021,15 +4021,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoSMem(option, &(argv[2]));
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), &(argv[3]));// This is the case of "depth".
                     }
-                    
+
                     case 'r':
                     {
                         // case: remove requires one non-option argument, but can have a "force" argument
@@ -4037,15 +4037,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoSMem(option, &(argv[2]));
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), &(argv[3]));//
                     }
-                    
+
                     case 's':
                     {
                         // case: set requires two non-option arguments
@@ -4053,10 +4053,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 'S':
                     {
                         // case: stat can do zero or one non-option arguments
@@ -4064,15 +4064,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoSMem('S');
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]));
                     }
-                    
+
                     case 't':
                     {
                         // case: timer can do zero or one non-option arguments
@@ -4080,15 +4080,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoSMem('t');
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]));
                     }
-                    
+
                     case 'v':
                     {
                         // case: viz does zero or 1/2 non-option arguments
@@ -4096,37 +4096,37 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoSMem(option);
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 1)
                         {
                             return cli.DoSMem(option, &(argv[2]), 0);
                         }
-                        
+
                         return cli.DoSMem(option, &(argv[2]), &(argv[3]));
                     }
                 }
-                
+
                 // bad: no option, but more than one argument
                 if (argv.size() > 1)
                 {
                     return cli.SetError("Too many arguments.");
                 }
-                
+
                 // case: nothing = full configuration information
                 return cli.DoSMem();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SMemCommand& operator=(const SMemCommand&);
     };
-    
+
     class SoarNewsCommand : public cli::ParserCommand
     {
         public:
@@ -4140,18 +4140,18 @@ namespace cli
             {
                 return "Syntax: soarnews";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoSoarNews();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SoarNewsCommand& operator=(const SoarNewsCommand&);
     };
-    
+
     class SourceCommand : public cli::ParserCommand
     {
         public:
@@ -4166,7 +4166,7 @@ namespace cli
                 return
                     "Syntax: source [options] filename";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4177,9 +4177,9 @@ namespace cli
                     {'v', "verbose",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::SourceBitset options(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4191,7 +4191,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -4205,7 +4205,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() < 1)
                 {
                     return cli.SetError(GetSyntax());
@@ -4214,16 +4214,16 @@ namespace cli
                 {
                     return cli.SetError("Please supply one file to source. If there are spaces in the path, enclose it in quotes.");
                 }
-                
+
                 return cli.DoSource(argv[opt.GetArgument() - opt.GetNonOptionArguments()], &options);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SourceCommand& operator=(const SourceCommand&);
     };
-    
+
     class SPCommand : public cli::ParserCommand
     {
         public:
@@ -4238,7 +4238,7 @@ namespace cli
                 return
                     "Syntax: sp {production_body}";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // One argument (the stuff in the brackets, minus the brackets
@@ -4250,16 +4250,16 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoSP(argv[1]);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SPCommand& operator=(const SPCommand&);
     };
-    
+
     class SRandCommand : public cli::ParserCommand
     {
         public:
@@ -4274,30 +4274,30 @@ namespace cli
                 return
                     "Syntax: srand [seed]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 if (argv.size() < 2)
                 {
                     return cli.DoSRand();
                 }
-                
+
                 if (argv.size() > 2)
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 uint32_t seed = 0;
                 sscanf(argv[1].c_str(), "%u", &seed);
                 return cli.DoSRand(&seed);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             SRandCommand& operator=(const SRandCommand&);
     };
-    
+
     class StatsCommand : public cli::ParserCommand
     {
         public:
@@ -4312,7 +4312,7 @@ namespace cli
                 return
                     "Syntax: stats [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4332,10 +4332,10 @@ namespace cli
                     {'a', "agent",      OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::StatsBitset options(0);
                 int sort = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4347,7 +4347,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -4392,22 +4392,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // No arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoStats(options, sort);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             StatsCommand& operator=(const StatsCommand&);
     };
-    
+
     class StopSoarCommand : public cli::ParserCommand
     {
         public:
@@ -4422,7 +4422,7 @@ namespace cli
                 return
                     "Syntax: stop-soar [-s] [reason string]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4431,9 +4431,9 @@ namespace cli
                     {'s', "self",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool self = false;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4445,7 +4445,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 's':
@@ -4453,7 +4453,7 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // Concatinate remaining args for 'reason'
                 if (opt.GetNonOptionArguments())
                 {
@@ -4467,13 +4467,13 @@ namespace cli
                 }
                 return cli.DoStopSoar(self);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             StopSoarCommand& operator=(const StopSoarCommand&);
     };
-    
+
     class TimeCommand : public cli::ParserCommand
     {
         public:
@@ -4487,7 +4487,7 @@ namespace cli
             {
                 return "Syntax: time command [arguments]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // There must at least be a command
@@ -4495,19 +4495,19 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 std::vector<std::string>::iterator iter = argv.begin();
                 argv.erase(iter);
-                
+
                 return cli.DoTime(argv);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             TimeCommand& operator=(const TimeCommand&);
     };
-    
+
     class TimersCommand : public cli::ParserCommand
     {
         public:
@@ -4521,7 +4521,7 @@ namespace cli
             {
                 return "Syntax: timers [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4533,10 +4533,10 @@ namespace cli
                     {'e', "on",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool print = true;
                 bool setting = false;    // enable or disable timers, default of false ignored
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4548,7 +4548,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'e':
@@ -4561,22 +4561,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // No non-option arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoTimers(print ? 0 : &setting);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             TimersCommand& operator=(const TimersCommand&);
     };
-    
+
     class UnaliasCommand : public cli::ParserCommand
     {
         public:
@@ -4590,7 +4590,7 @@ namespace cli
             {
                 return "Syntax: unalias name";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 // Need exactly one argument
@@ -4602,17 +4602,17 @@ namespace cli
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 argv.erase(argv.begin());
                 return cli.DoUnalias(argv);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             UnaliasCommand& operator=(const UnaliasCommand&);
     };
-    
+
     class VerboseCommand : public cli::ParserCommand
     {
         public:
@@ -4626,7 +4626,7 @@ namespace cli
             {
                 return "Syntax: verbose [-ed]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4638,10 +4638,10 @@ namespace cli
                     {'e', "onn",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool setting = false;
                 bool query = true;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4653,7 +4653,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -4666,21 +4666,21 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoVerbose(query ? 0 : &setting);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             VerboseCommand& operator=(const VerboseCommand&);
     };
-    
+
     class VersionCommand : public cli::ParserCommand
     {
         public:
@@ -4694,18 +4694,18 @@ namespace cli
             {
                 return "Syntax: version";
             }
-            
+
             virtual bool Parse(std::vector< std::string >&)
             {
                 return cli.DoVersion();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             VersionCommand& operator=(const VersionCommand&);
     };
-    
+
     class WaitSNCCommand : public cli::ParserCommand
     {
         public:
@@ -4719,7 +4719,7 @@ namespace cli
             {
                 return "Syntax: waitsnc -[e|d]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4731,10 +4731,10 @@ namespace cli
                     {'e', "on",            OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool query = true;
                 bool enable = false;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4746,7 +4746,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'd':
@@ -4759,22 +4759,22 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 // No additional arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoWaitSNC(query ? 0 : &enable);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             WaitSNCCommand& operator=(const WaitSNCCommand&);
     };
-    
+
     class WarningsCommand : public cli::ParserCommand
     {
         public:
@@ -4789,7 +4789,7 @@ namespace cli
                 return
                     "Syntax: warnings [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4801,10 +4801,10 @@ namespace cli
                     {'d', "off",        OPTARG_NONE},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 bool query = true;
                 bool setting = true;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -4816,7 +4816,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'e':
@@ -4829,21 +4829,21 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments())
                 {
                     cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoWarnings(query ? 0 : &setting);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             WarningsCommand& operator=(const WarningsCommand&);
     };
-    
+
     class WatchCommand : public cli::ParserCommand
     {
         public:
@@ -4857,7 +4857,7 @@ namespace cli
             {
                 return "Syntax: watch [options]\nwatch [level]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -4889,24 +4889,24 @@ namespace cli
                     {'W', "waterfall",                   OPTARG_OPTIONAL}, // TODO: document. note: added to watch 5
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::WatchBitset options(0);
                 Cli::WatchBitset settings(0);
                 int learnSetting = 0;
                 int wmeSetting = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -4924,7 +4924,7 @@ namespace cli
                                 settings.set(Cli::WATCH_WMA);
                             }
                             break;
-                            
+
                         case 'b':
                             options.set(Cli::WATCH_BACKTRACING);
                             if (opt.GetOptionArgument().size())
@@ -4940,7 +4940,7 @@ namespace cli
                                 settings.set(Cli::WATCH_BACKTRACING);
                             }
                             break;
-                            
+
                         case 'c':
                             options.set(Cli::WATCH_CHUNKS);
                             if (opt.GetOptionArgument().size())
@@ -4956,7 +4956,7 @@ namespace cli
                                 settings.set(Cli::WATCH_CHUNKS);
                             }
                             break;
-                            
+
                         case 'd':
                             options.set(Cli::WATCH_DECISIONS);
                             if (opt.GetOptionArgument().size())
@@ -4972,7 +4972,7 @@ namespace cli
                                 settings.set(Cli::WATCH_DECISIONS);
                             }
                             break;
-                            
+
                         case 'D':
                             options.set(Cli::WATCH_DEFAULT);
                             if (opt.GetOptionArgument().size())
@@ -4988,7 +4988,7 @@ namespace cli
                                 settings.set(Cli::WATCH_DEFAULT);
                             }
                             break;
-                            
+
                         case 'e':
                             options.set(Cli::WATCH_EPMEM);
                             if (opt.GetOptionArgument().size())
@@ -5004,12 +5004,12 @@ namespace cli
                                 settings.set(Cli::WATCH_EPMEM);
                             }
                             break;
-                            
+
                         case 'f': // fullwmes
                             options.set(Cli::WATCH_WME_DETAIL);
                             wmeSetting = 2;
                             break;
-                            
+
                         case 'g':
                             options.set(Cli::WATCH_GDS);
                             if (opt.GetOptionArgument().size())
@@ -5025,7 +5025,7 @@ namespace cli
                                 settings.set(Cli::WATCH_GDS);
                             }
                             break;
-                            
+
                         case 'i':
                             options.set(Cli::WATCH_INDIFFERENT);
                             if (opt.GetOptionArgument().size())
@@ -5041,7 +5041,7 @@ namespace cli
                                 settings.set(Cli::WATCH_INDIFFERENT);
                             }
                             break;
-                            
+
                         case 'j':
                             options.set(Cli::WATCH_JUSTIFICATIONS);
                             if (opt.GetOptionArgument().size())
@@ -5057,7 +5057,7 @@ namespace cli
                                 settings.set(Cli::WATCH_JUSTIFICATIONS);
                             }
                             break;
-                            
+
                         case 'L':
                             options.set(Cli::WATCH_LEARNING);
                             learnSetting = ParseLearningOptarg(opt);
@@ -5066,7 +5066,7 @@ namespace cli
                                 return cli.SetError(opt.GetError().c_str());
                             }
                             break;
-                            
+
                         case 'l':
                         {
                             int level = 0;
@@ -5074,14 +5074,14 @@ namespace cli
                             {
                                 return cli.SetError("Integer argument expected.");
                             }
-                            
+
                             if (!ProcessWatchLevelSettings(level, options, settings, wmeSetting, learnSetting))
                             {
                                 return cli.SetError(opt.GetError().c_str());
                             }
                         }
                         break;
-                        
+
                         case 'N': // none
                             options.reset();
                             options.flip();
@@ -5089,12 +5089,12 @@ namespace cli
                             learnSetting = 0;
                             wmeSetting = 0;
                             break;
-                            
+
                         case 'n': // nowmes
                             options.set(Cli::WATCH_WME_DETAIL);
                             wmeSetting = 0;
                             break;
-                            
+
                         case 'p':
                             options.set(Cli::WATCH_PHASES);
                             if (opt.GetOptionArgument().size())
@@ -5110,7 +5110,7 @@ namespace cli
                                 settings.set(Cli::WATCH_PHASES);
                             }
                             break;
-                            
+
                         case 'P': // productions (all)
                             options.set(Cli::WATCH_DEFAULT);
                             options.set(Cli::WATCH_USER);
@@ -5135,7 +5135,7 @@ namespace cli
                                 settings.set(Cli::WATCH_JUSTIFICATIONS);
                             }
                             break;
-                            
+
                         case 'r':
                             options.set(Cli::WATCH_PREFERENCES);
                             if (opt.GetOptionArgument().size())
@@ -5151,7 +5151,7 @@ namespace cli
                                 settings.set(Cli::WATCH_PREFERENCES);
                             }
                             break;
-                            
+
                         case 'R':
                             options.set(Cli::WATCH_RL);
                             if (opt.GetOptionArgument().size())
@@ -5167,7 +5167,7 @@ namespace cli
                                 settings.set(Cli::WATCH_RL);
                             }
                             break;
-                            
+
                         case 's':
                             options.set(Cli::WATCH_SMEM);
                             if (opt.GetOptionArgument().size())
@@ -5183,12 +5183,12 @@ namespace cli
                                 settings.set(Cli::WATCH_SMEM);
                             }
                             break;
-                            
+
                         case 't'://timetags
                             options.set(Cli::WATCH_WME_DETAIL);
                             wmeSetting = 1;
                             break;
-                            
+
                         case 'T':
                             options.set(Cli::WATCH_TEMPLATES);
                             if (opt.GetOptionArgument().size())
@@ -5204,7 +5204,7 @@ namespace cli
                                 settings.set(Cli::WATCH_TEMPLATES);
                             }
                             break;
-                            
+
                         case 'u':
                             options.set(Cli::WATCH_USER);
                             if (opt.GetOptionArgument().size())
@@ -5252,12 +5252,12 @@ namespace cli
                             break;
                     }
                 }
-                
+
                 if (opt.GetNonOptionArguments() > 1)
                 {
                     return cli.SetError("Only non option argument allowed is watch level.");
                 }
-                
+
                 // Allow watch level by itself
                 if (opt.GetNonOptionArguments() == 1)
                 {
@@ -5272,25 +5272,25 @@ namespace cli
                         return cli.SetError(opt.GetError().c_str());
                     }
                 }
-                
+
                 return cli.DoWatch(options, settings, wmeSetting, learnSetting);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             bool ProcessWatchLevelSettings(const int level, Cli::WatchBitset& options, Cli::WatchBitset& settings, int& wmeSetting, int& learnSetting)
             {
                 if (level < 0)
                 {
                     return cli.SetError("Expected watch level from 0 to 5.");
                 }
-                
+
                 if (level > 5)
                 {
                     return cli.SetError("Expected watch level from 0 to 5.");
                 }
-                
+
                 // All of these are going to change
                 options.set(Cli::WATCH_PREFERENCES);
                 options.set(Cli::WATCH_WMES);
@@ -5303,7 +5303,7 @@ namespace cli
                 options.set(Cli::WATCH_DECISIONS);
                 options.set(Cli::WATCH_WATERFALL);
                 options.set(Cli::WATCH_GDS);
-                
+
                 // Start with all off, turn on as appropriate
                 settings.reset(Cli::WATCH_PREFERENCES);
                 settings.reset(Cli::WATCH_WMES);
@@ -5316,7 +5316,7 @@ namespace cli
                 settings.reset(Cli::WATCH_DECISIONS);
                 settings.reset(Cli::WATCH_WATERFALL);
                 settings.reset(Cli::WATCH_GDS);
-                
+
                 switch (level)
                 {
                     case 0:// none
@@ -5326,7 +5326,7 @@ namespace cli
                         learnSetting = 0;
                         wmeSetting = 0;
                         break;
-                        
+
                     case 5:// preferences, waterfall
                         settings.set(Cli::WATCH_PREFERENCES);
                         settings.set(Cli::WATCH_WATERFALL);
@@ -5351,7 +5351,7 @@ namespace cli
                 }
                 return true;
             }
-            
+
             int ParseLearningOptarg(cli::Options& opt)
             {
                 if (opt.GetOptionArgument() == "noprint"   || opt.GetOptionArgument() == "0")
@@ -5366,24 +5366,24 @@ namespace cli
                 {
                     return 2;
                 }
-                
+
                 cli.SetError("Invalid learn setting, expected noprint, print, fullprint, or 0-2. Got: " + opt.GetOptionArgument());
                 return -1;
             }
-            
+
             bool CheckOptargRemoveOrZero(cli::Options& opt)
             {
                 if (opt.GetOptionArgument() == "remove" || opt.GetOptionArgument() == "0")
                 {
                     return true;
                 }
-                
+
                 return cli.SetError("Invalid argument, expected remove or 0. Got: " + opt.GetOptionArgument());
             }
-            
+
             WatchCommand& operator=(const WatchCommand&);
     };
-    
+
     class WatchWMEsCommand : public cli::ParserCommand
     {
         public:
@@ -5397,7 +5397,7 @@ namespace cli
             {
                 return "Syntax: watch-wmes -[a|r]  -t type  pattern\nwatch-wmes -[l|R] [-t type]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -5410,10 +5410,10 @@ namespace cli
                     {'t', "type",            OPTARG_REQUIRED},
                     {0, 0, OPTARG_NONE}
                 };
-                
+
                 Cli::eWatchWMEsMode mode = Cli::WATCH_WMES_LIST;
                 Cli::WatchWMEsTypeBitset type(0);
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
@@ -5425,7 +5425,7 @@ namespace cli
                     {
                         break;
                     }
-                    
+
                     switch (opt.GetOption())
                     {
                         case 'a':
@@ -5464,7 +5464,7 @@ namespace cli
                         break;
                     }
                 }
-                
+
                 if (mode == Cli::WATCH_WMES_ADD || mode == Cli::WATCH_WMES_REMOVE)
                 {
                     // type required
@@ -5472,7 +5472,7 @@ namespace cli
                     {
                         return cli.SetError("Wme type required.");
                     }
-                    
+
                     // check for too few/many args
                     if (opt.GetNonOptionArguments() > 3)
                     {
@@ -5482,26 +5482,26 @@ namespace cli
                     {
                         return cli.SetError(GetSyntax());
                     }
-                    
+
                     int optind = opt.GetArgument() - opt.GetNonOptionArguments();
                     return cli.DoWatchWMEs(mode, type, &argv[optind], &argv[optind + 1], &argv[optind + 2]);
                 }
-                
+
                 // no additional arguments
                 if (opt.GetNonOptionArguments())
                 {
                     return cli.SetError(GetSyntax());
                 }
-                
+
                 return cli.DoWatchWMEs(mode, type);
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             WatchWMEsCommand& operator=(const WatchWMEsCommand&);
     };
-    
+
     class WMACommand : public cli::ParserCommand
     {
         public:
@@ -5515,7 +5515,7 @@ namespace cli
             {
                 return "Syntax: wma [options]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 cli::Options opt;
@@ -5528,36 +5528,36 @@ namespace cli
                     {'t', "timers",     OPTARG_NONE},
                     {0, 0, OPTARG_NONE} // null
                 };
-                
+
                 char option = 0;
-                
+
                 for (;;)
                 {
                     if (!opt.ProcessOptions(argv, optionsData))
                     {
                         return cli.SetError(opt.GetError().c_str());
                     }
-                    
+
                     if (opt.GetOption() == -1)
                     {
                         break;
                     }
-                    
+
                     if (option != 0)
                     {
                         return cli.SetError("wma takes only one option at a time.");
                     }
-                    
+
                     option = static_cast<char>(opt.GetOption());
                 }
-                
+
                 switch (option)
                 {
                     case 0:
                     default:
                         // no options
                         break;
-                        
+
                     case 'g':
                         // case: get requires one non-option argument
                     {
@@ -5565,10 +5565,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoWMA(option, &(argv[2]));
                     }
-                    
+
                     case 'h':
                         // case: history requires one non-option argument
                     {
@@ -5576,10 +5576,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoWMA(option, &(argv[2]));
                     }
-                    
+
                     case 's':
                         // case: set requires two non-option arguments
                     {
@@ -5587,10 +5587,10 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         return cli.DoWMA(option, &(argv[2]), &(argv[3]));
                     }
-                    
+
                     case 'S':
                         // case: stat can do zero or one non-option arguments
                     {
@@ -5598,15 +5598,15 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoWMA('S');
                         }
-                        
+
                         return cli.DoWMA(option, &(argv[2]));
                     }
-                    
+
                     case 't':
                         // case: timer can do zero or one non-option arguments
                     {
@@ -5614,32 +5614,33 @@ namespace cli
                         {
                             return cli.SetError(opt.GetError().c_str());
                         }
-                        
+
                         if (opt.GetNonOptionArguments() == 0)
                         {
                             return cli.DoWMA(option);
                         }
-                        
+
                         return cli.DoWMA(option, &(argv[2]));
                     }
                 }
-                
+
                 // bad: no option, but more than one argument
                 if (argv.size() > 1)
                 {
                     return cli.SetError("Too many args.");
                 }
-                
+
                 // case: nothing = full configuration information
                 return cli.DoWMA();
             }
-            
+
         private:
             cli::Cli& cli;
-            
+
             WMACommand& operator=(const WMACommand&);
     };
-    
+
+#ifndef NO_SVS
     class SVSCommand : public cli::ParserCommand
     {
         public:
@@ -5654,16 +5655,16 @@ namespace cli
                 return "Syntax: svs <elements to inspect>\n"
                        "        svs [--enable | -e | --on | --disable | -d | --off]";
             }
-            
+
             virtual bool Parse(std::vector< std::string >& argv)
             {
                 return cli.DoSVS(argv);
             }
-            
+
         private:
             cli::Cli& cli;
     };
-    
+#endif
 }
 
 #endif // CLI_COMMANDS_H

--- a/Core/CLI/src/cli_svs.cpp
+++ b/Core/CLI/src/cli_svs.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_SVS
 #include "cli_CommandLineInterface.h"
 #include "sml_AgentSML.h"
 #include "agent.h"
@@ -10,7 +11,7 @@ bool CommandLineInterface::DoSVS(const std::vector<std::string>& args)
 {
     std::string out;
     agent* thisAgent = m_pAgentSML->GetSoarAgent();
-    
+
     if (args.size() == 1)
     {
         m_Result << "Spatial Visual System is " << (thisAgent->svs->is_enabled() ? "enabled." : "disabled.");
@@ -64,3 +65,4 @@ bool CommandLineInterface::DoSVS(const std::vector<std::string>& args)
         return false;
     }
 }
+#endif

--- a/Core/ClientSML/src/sml_ClientAgent.cpp
+++ b/Core/ClientSML/src/sml_ClientAgent.cpp
@@ -65,11 +65,11 @@ Agent::Agent(Kernel* pKernel, char const* pName)
     m_CallbackIDCounter = 0 ;
     m_XMLCallback = -1 ;
     m_BlinkIfNoChange = true ;
-    
+
     m_WorkingMemory.SetAgent(this) ;
-    
+
     m_pDPI = 0;
-    
+
     ClearError() ;
 }
 
@@ -91,16 +91,16 @@ void Agent::ReceivedOutput(AnalyzeXML* pIncoming, ElementXML* pResponse)
 void Agent::ReceivedEvent(AnalyzeXML* pIncoming, ElementXML* pResponse)
 {
     char const* pEventName = pIncoming->GetArgString(sml_Names::kParamEventID) ;
-    
+
     // This event had no event id field
     if (!pEventName)
     {
         return ;
     }
-    
+
     // Go from the string form of the event back to the integer ID
     int id = GetKernel()->m_pEventMap->ConvertToEvent(pEventName) ;
-    
+
     if (IsRunEventID(id))
     {
         ReceivedRunEvent(smlRunEventId(id), pIncoming, pResponse) ;
@@ -122,24 +122,24 @@ void Agent::ReceivedEvent(AnalyzeXML* pIncoming, ElementXML* pResponse)
 void Agent::ReceivedRunEvent(smlRunEventId id, AnalyzeXML* pIncoming, ElementXML* /*pResponse*/)
 {
     smlPhase phase = smlPhase(pIncoming->GetArgInt(sml_Names::kParamPhase, -1)) ;
-    
+
     // Look up the handler(s) from the map
     RunEventMap::ValueList* pHandlers = m_RunEventMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (RunEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ;)
     {
         RunEventHandlerPlusData handlerWithData = *iter ;
         iter++ ;
-        
+
         RunEventHandler handler = handlerWithData.m_Handler ;
         void* pUserData = handlerWithData.m_UserData ;
-        
+
         // Call the handler
         handler(id, pUserData, this, phase) ;
     }
@@ -148,24 +148,24 @@ void Agent::ReceivedRunEvent(smlRunEventId id, AnalyzeXML* pIncoming, ElementXML
 void Agent::FireOutputNotification()
 {
     smlWorkingMemoryEventId id = smlEVENT_OUTPUT_PHASE_CALLBACK ;
-    
+
     // Look up the handler(s) from the map
     OutputNotificationMap::ValueList* pHandlers = m_OutputNotificationMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (OutputNotificationMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ;)
     {
         OutputNotificationHandlerPlusData handlerWithData = *iter ;
         iter++ ;
-        
+
         OutputNotificationHandler handler = handlerWithData.m_Handler ;
         void* pUserData = handlerWithData.m_UserData ;
-        
+
         // Call the handler
         handler(pUserData, this) ;
     }
@@ -174,33 +174,33 @@ void Agent::FireOutputNotification()
 void Agent::ReceivedPrintEvent(smlPrintEventId id, AnalyzeXML* pIncoming, ElementXML* /*pResponse*/)
 {
     char const* pMessage = pIncoming->GetArgString(sml_Names::kParamMessage) ;
-    
+
     // This argument is only present on echo messages.
     bool self = pIncoming->GetArgBool(sml_Names::kParamSelf, false) ;
-    
+
     // Look up the handler(s) from the map
     PrintEventMap::ValueList* pHandlers = m_PrintEventMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (PrintEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ; iter++)
     {
         PrintEventHandlerPlusData handlerPlus = *iter ;
         PrintEventHandler handler = handlerPlus.m_Handler ;
         bool ignoreOwnEchos = handlerPlus.m_IgnoreOwnEchos ;
-        
+
         // If this is an echo event triggered by a command issued by ourselves ignore it.
         if (id == smlEVENT_ECHO && ignoreOwnEchos && self)
         {
             continue ;
         }
-        
+
         void* pUserData = handlerPlus.m_UserData ;
-        
+
         // Call the handler
         handler(id, pUserData, this, pMessage) ;
     }
@@ -210,23 +210,23 @@ void Agent::ReceivedProductionEvent(smlProductionEventId id, AnalyzeXML* pIncomi
 {
     char const* pProductionName = pIncoming->GetArgString(sml_Names::kParamName) ;
     char const* pInstance = 0 ; // gSKI defines this but doesn't support it yet.
-    
+
     // Look up the handler(s) from the map
     ProductionEventMap::ValueList* pHandlers = m_ProductionEventMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (ProductionEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ; iter++)
     {
         ProductionEventHandlerPlusData handlerPlus = *iter ;
-        
+
         ProductionEventHandler handler = handlerPlus.m_Handler ;
         void* pUserData = handlerPlus.m_UserData ;
-        
+
         // Call the handler
         handler(id, pUserData, this, pProductionName, pInstance) ;
     }
@@ -238,7 +238,7 @@ bool Agent::LoadProductions(char const* pFilename, bool echoResults)
     {
         return false;
     }
-    
+
     // remove quotes or braces if they exist
     std::string cmd("source {");
     size_t len = strlen(pFilename);
@@ -251,12 +251,12 @@ bool Agent::LoadProductions(char const* pFilename, bool echoResults)
         cmd.append(pFilename, len);
     }
     cmd.push_back('}');
-    
+
     // Execute the source command, insert braces
     char const* pResult = ExecuteCommandLine(cmd.c_str(), echoResults) ;
-    
+
     bool ok = GetLastCommandLineResult() ;
-    
+
     if (ok)
     {
         ClearError() ;
@@ -265,7 +265,7 @@ bool Agent::LoadProductions(char const* pFilename, bool echoResults)
     {
         SetDetailedError(Error::kDetailedError, pResult) ;
     }
-    
+
     return ok ;
 }
 
@@ -279,7 +279,7 @@ class Agent::TestRunCallback : public RunEventMap::ValueTest
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(RunEventHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -292,7 +292,7 @@ class Agent::TestRunCallbackFull : public RunEventMap::ValueTest
         int             m_EventID ;
         RunEventHandler m_Handler ;
         void*           m_UserData ;
-        
+
     public:
         TestRunCallbackFull(int id, RunEventHandler handler, void* pUserData)
         {
@@ -300,7 +300,7 @@ class Agent::TestRunCallbackFull : public RunEventMap::ValueTest
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         bool isEqual(RunEventHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_EventID == m_EventID &&
@@ -318,7 +318,7 @@ class Agent::TestOutputNotificationCallback : public OutputNotificationMap::Valu
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(OutputNotificationHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -331,7 +331,7 @@ class Agent::TestOutputNotificationCallbackFull : public OutputNotificationMap::
         int             m_EventID ;
         OutputNotificationHandler m_Handler ;
         void*           m_UserData ;
-        
+
     public:
         TestOutputNotificationCallbackFull(int id, OutputNotificationHandler handler, void* pUserData)
         {
@@ -339,7 +339,7 @@ class Agent::TestOutputNotificationCallbackFull : public OutputNotificationMap::
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         bool isEqual(OutputNotificationHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_EventID == m_EventID &&
@@ -357,7 +357,7 @@ class Agent::TestOutputCallback : public OutputEventMap::ValueTest
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(OutputEventHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -370,7 +370,7 @@ class Agent::TestOutputCallbackFull : public OutputEventMap::ValueTest
         std::string         m_AttributeName ;
         OutputEventHandler  m_Handler ;
         void*               m_UserData ;
-        
+
     public:
         TestOutputCallbackFull(char const* attributeName, OutputEventHandler handler, void* pUserData)
         {
@@ -378,9 +378,9 @@ class Agent::TestOutputCallbackFull : public OutputEventMap::ValueTest
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         virtual ~TestOutputCallbackFull() { } ;
-        
+
         bool isEqual(OutputEventHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_AttributeName.compare(m_AttributeName) == 0 &&
@@ -398,7 +398,7 @@ class Agent::TestProductionCallback : public ProductionEventMap::ValueTest
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(ProductionEventHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -411,7 +411,7 @@ class Agent::TestProductionCallbackFull : public ProductionEventMap::ValueTest
         int             m_EventID ;
         ProductionEventHandler m_Handler ;
         void*           m_UserData ;
-        
+
     public:
         TestProductionCallbackFull(int id, ProductionEventHandler handler, void* pUserData)
         {
@@ -419,7 +419,7 @@ class Agent::TestProductionCallbackFull : public ProductionEventMap::ValueTest
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         bool isEqual(ProductionEventHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_EventID == m_EventID &&
@@ -437,7 +437,7 @@ class Agent::TestPrintCallback : public PrintEventMap::ValueTest
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(PrintEventHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -450,7 +450,7 @@ class Agent::TestPrintCallbackFull : public PrintEventMap::ValueTest
         int             m_EventID ;
         PrintEventHandler m_Handler ;
         void*           m_UserData ;
-        
+
     public:
         TestPrintCallbackFull(int id, PrintEventHandler handler, void* pUserData)
         {
@@ -458,7 +458,7 @@ class Agent::TestPrintCallbackFull : public PrintEventMap::ValueTest
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         bool isEqual(PrintEventHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_EventID == m_EventID &&
@@ -476,7 +476,7 @@ class Agent::TestXMLCallback : public XMLEventMap::ValueTest
         {
             m_ID = id ;
         }
-        
+
         bool isEqual(XMLEventHandlerPlusData handler)
         {
             return handler.m_CallbackID == m_ID ;
@@ -489,7 +489,7 @@ class Agent::TestXMLCallbackFull : public XMLEventMap::ValueTest
         int             m_EventID ;
         XMLEventHandler m_Handler ;
         void*           m_UserData ;
-        
+
     public:
         TestXMLCallbackFull(int id, XMLEventHandler handler, void* pUserData)
         {
@@ -497,7 +497,7 @@ class Agent::TestXMLCallbackFull : public XMLEventMap::ValueTest
             m_Handler = handler ;
             m_UserData = pUserData ;
         }
-        
+
         bool isEqual(XMLEventHandlerPlusData handlerPlus)
         {
             return handlerPlus.m_EventID == m_EventID &&
@@ -510,31 +510,31 @@ int Agent::RegisterForRunEvent(smlRunEventId id, RunEventHandler handler, void* 
 {
     // Start by checking if this id, handler, pUSerData combination has already been registered
     TestRunCallbackFull test(id, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     RunEventHandlerPlusData plus(0, 0, 0, 0) ;
     bool found = m_RunEventMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // If we have no handlers registered with the kernel, then we need
     // to register for this event.  No need to do this multiple times.
     if (m_RunEventMap.getListSize(id) == 0)
     {
         GetKernel()->RegisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
-    
+
     // We use a struct rather than a pointer to a struct, so there's no need to new/delete
     // everything as the objects are added and deleted.
     RunEventHandlerPlusData handlerPlus(id, handler, pUserData, m_CallbackIDCounter) ;
     m_RunEventMap.add(id, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -543,43 +543,43 @@ bool Agent::UnregisterForRunEvent(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestRunCallback test(callbackID) ;
-    
+
     // Find the event ID for this callbackID
     smlRunEventId id = m_RunEventMap.findFirstKeyByTest(&test, smlRUN_EVENT_BAD) ;
-    
+
     if (id == smlRUN_EVENT_BAD)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_RunEventMap.removeAllByTest(&test) ;
-    
+
     // If we just removed the last handler, then unregister from the kernel for this event
     if (m_RunEventMap.getListSize(id) == 0)
     {
         GetKernel()->UnregisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     return true ;
 }
 
 int Agent::RegisterForOutputNotification(OutputNotificationHandler handler, void* pUserData, bool addToBack)
 {
     smlWorkingMemoryEventId id = smlEVENT_OUTPUT_PHASE_CALLBACK ;
-    
+
     // Start by checking if this id, handler, pUSerData combination has already been registered
     TestOutputNotificationCallbackFull test(id, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     OutputNotificationHandlerPlusData plus(0, 0, 0, 0) ;
     bool found = m_OutputNotificationMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // If we have no handlers registered with the kernel, then we need
     // to register for this event.  No need to do this multiple times.
     // (Only do this if we were ignoring output from the kernel already--otherwise we'll get two copies of everything
@@ -588,15 +588,15 @@ int Agent::RegisterForOutputNotification(OutputNotificationHandler handler, void
     {
         GetKernel()->RegisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
-    
+
     // We use a struct rather than a pointer to a struct, so there's no need to new/delete
     // everything as the objects are added and deleted.
     OutputNotificationHandlerPlusData handlerPlus(id, handler, pUserData, m_CallbackIDCounter) ;
     m_OutputNotificationMap.add(id, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -605,48 +605,48 @@ bool Agent::UnregisterForOutputNotification(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestOutputNotificationCallback test(callbackID) ;
-    
+
     // Find the event ID for this callbackID
     smlWorkingMemoryEventId id = m_OutputNotificationMap.findFirstKeyByTest(&test, smlWORKING_MEMORY_EVENT_BAD) ;
-    
+
     if (id == smlWORKING_MEMORY_EVENT_BAD)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_OutputNotificationMap.removeAllByTest(&test) ;
-    
+
     // If we just removed the last handler, then unregister from the kernel for this event
     if (GetKernel()->m_bIgnoreOutput && m_OutputNotificationMap.getListSize(id) == 0)
     {
         GetKernel()->UnregisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     return true ;
 }
 
 int Agent::AddOutputHandler(char const* pAttributeName, OutputEventHandler handler, void* pUserData, bool addToBack)
 {
     m_WorkingMemory.SetOutputLinkChangeTracking(true);
-    
+
     // Start by checking if this attributeName, handler, pUSerData combination has already been registered
     TestOutputCallbackFull test(pAttributeName, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     OutputEventHandlerPlusData plus(0, 0, 0, 0, 0) ;
     bool found = m_OutputEventMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
     OutputEventHandlerPlusData handlerPlus(0, pAttributeName, handler, pUserData, m_CallbackIDCounter) ;
     m_OutputEventMap.add(pAttributeName, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -655,18 +655,18 @@ bool Agent::RemoveOutputHandler(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestOutputCallback test(callbackID) ;
-    
+
     // Find the function for this callbackID (for RHS functions the key is a function name not an event id)
     std::string functionName = m_OutputEventMap.findFirstKeyByTest(&test, "") ;
-    
+
     if (functionName.length() == 0)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_OutputEventMap.removeAllByTest(&test) ;
-    
+
     return true ;
 }
 
@@ -678,24 +678,24 @@ bool Agent::IsRegisteredForOutputEvent()
 void Agent::ReceivedOutputEvent(WMElement* pWmeAdded)
 {
     char const* pAttributeName = pWmeAdded->GetAttribute() ;
-    
+
     // Look up the handler(s) from the map
     OutputEventMap::ValueList* pHandlers = m_OutputEventMap.getList(pAttributeName) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (OutputEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ;)
     {
         OutputEventHandlerPlusData handlerWithData = *iter ;
         iter++ ;
-        
+
         OutputEventHandler handler = handlerWithData.m_Handler ;
         void* pUserData = handlerWithData.getUserData() ;
-        
+
         // Call the handler
         handler(pUserData, this, pAttributeName, pWmeAdded) ;
     }
@@ -705,28 +705,28 @@ int Agent::RegisterForProductionEvent(smlProductionEventId id, ProductionEventHa
 {
     // Start by checking if this id, handler, pUSerData combination has already been registered
     TestProductionCallbackFull test(id, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     ProductionEventHandlerPlusData plus(0, 0, 0, 0) ;
     bool found = m_ProductionEventMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // If we have no handlers registered with the kernel, then we need
     // to register for this event.  No need to do this multiple times.
     if (m_ProductionEventMap.getListSize(id) == 0)
     {
         GetKernel()->RegisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
     ProductionEventHandlerPlusData handlerPlus(id, handler, pUserData, m_CallbackIDCounter) ;
     m_ProductionEventMap.add(id, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -735,24 +735,24 @@ bool Agent::UnregisterForProductionEvent(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestProductionCallback test(callbackID) ;
-    
+
     // Find the event ID for this callbackID
     smlProductionEventId id = m_ProductionEventMap.findFirstKeyByTest(&test, smlPRODUCTION_EVENT_BAD) ;
-    
+
     if (id == smlPRODUCTION_EVENT_BAD)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_ProductionEventMap.removeAllByTest(&test) ;
-    
+
     // If we just removed the last handler, then unregister from the kernel for this event
     if (m_ProductionEventMap.getListSize(id) == 0)
     {
         GetKernel()->UnregisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     return true ;
 }
 
@@ -760,29 +760,29 @@ int Agent::RegisterForPrintEvent(smlPrintEventId id, PrintEventHandler handler, 
 {
     // Start by checking if this id, handler, pUSerData combination has already been registered
     TestPrintCallbackFull test(id, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     PrintEventHandlerPlusData plus(0, 0, 0, false, 0) ;
     bool found = m_PrintEventMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // If we have no handlers registered with the kernel, then we need
     // to register for this event.  No need to do this multiple times.
     if (m_PrintEventMap.getListSize(id) == 0)
     {
         GetKernel()->RegisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
-    
+
     PrintEventHandlerPlusData handlerPlus(id, handler, pUserData, ignoreOwnEchos, m_CallbackIDCounter) ;
     m_PrintEventMap.add(id, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -791,24 +791,24 @@ bool Agent::UnregisterForPrintEvent(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestPrintCallback test(callbackID) ;
-    
+
     // Find the event ID for this callbackID
     smlPrintEventId id = m_PrintEventMap.findFirstKeyByTest(&test, smlPRINT_EVENT_BAD) ;
-    
+
     if (id == smlPRINT_EVENT_BAD)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_PrintEventMap.removeAllByTest(&test) ;
-    
+
     // If we just removed the last handler, then unregister from the kernel for this event
     if (m_PrintEventMap.getListSize(id) == 0)
     {
         GetKernel()->UnregisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     return true ;
 }
 
@@ -816,30 +816,30 @@ void Agent::ReceivedXMLEvent(smlXMLEventId id, AnalyzeXML* pIncoming, ElementXML
 {
     // Retrieve the original message
     ElementXML* pXMLMessage = new ElementXML(pIncoming->GetElementXMLHandle()) ;
-    
+
     // Need to record our new reference to this handle.
     pXMLMessage->AddRefOnHandle() ;
-    
+
     // NOTE: This object needs to stay in scope for as long as we're calling clients
     // and then when it is deleted it will delete pXMLMessage.
     ClientXML clientXML(pXMLMessage) ;
-    
+
     // Look up the handler(s) from the map
     XMLEventMap::ValueList* pHandlers = m_XMLEventMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (XMLEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ; iter++)
     {
         XMLEventHandlerPlusData handlerPlus = *iter ;
         XMLEventHandler handler = handlerPlus.m_Handler ;
-        
+
         void* pUserData = handlerPlus.m_UserData ;
-        
+
         // Call the handler
         handler(id, pUserData, this, &clientXML) ;
     }
@@ -851,7 +851,7 @@ void Agent::ReceivedXMLTraceEvent(smlXMLEventId id, ElementXML* pIncoming, Eleme
     char* pStr = pIncoming->GenerateXMLString(true) ;
     pIncoming->DeleteString(pStr) ;
 #endif
-    
+
     // For speed we don't analyze incoming XML trace messages.  Instead we just
     // look for the correct parts of the original message.  This makes these messages a bit
     // more brittle than the rest of the system but speed really counts on these messages and
@@ -859,35 +859,35 @@ void Agent::ReceivedXMLTraceEvent(smlXMLEventId id, ElementXML* pIncoming, Eleme
     // If this assert fails we've changed the structure of the XML event messages and we'll
     // need to update the code to match.
     assert(pIncoming->GetNumberChildren() == 2) ;
-    
+
     //  Get the trace tag (again, we rely on the order for speed).
     ElementXML* pTrace = new ElementXML(NULL) ;
     pIncoming->GetChild(pTrace, 1) ;
-    
+
     // NOTE: This object needs to stay in scope for as long as we're calling clients
     // and then when it is deleted it will delete pTrace.
     ClientXML clientXML(pTrace) ;
-    
+
     // Look up the handler(s) from the map
     XMLEventMap::ValueList* pHandlers = m_XMLEventMap.getList(id) ;
-    
+
     if (!pHandlers)
     {
         return ;
     }
-    
+
     // Go through the list of event handlers calling each in turn
     for (XMLEventMap::ValueListIter iter = pHandlers->begin() ; iter != pHandlers->end() ;)
     {
         XMLEventHandlerPlusData handlerPlus = *iter ;
         XMLEventHandler handler = handlerPlus.m_Handler ;
-        
+
         // Advance to the next handler before we make the callback, in case
         // the callback deletes the current handler from the list, invalidating the iterator.
         iter++ ;
-        
+
         void* pUserData = handlerPlus.m_UserData ;
-        
+
         // Call the handler
         handler(id, pUserData, this, &clientXML) ;
     }
@@ -897,16 +897,16 @@ int Agent::RegisterForXMLEvent(smlXMLEventId id, XMLEventHandler handler, void* 
 {
     // Start by checking if this id, handler, pUSerData combination has already been registered
     TestXMLCallbackFull test(id, handler, pUserData) ;
-    
+
     // See if this handler is already registered
     XMLEventHandlerPlusData plus(0, 0, 0, 0) ;
     bool found = m_XMLEventMap.findFirstValueByTest(&test, &plus) ;
-    
+
     if (found && plus.m_Handler != 0)
     {
         return plus.getCallbackID() ;
     }
-    
+
     // If we have no handlers registered with the kernel, then we need
     // to register for the print event (which we'll then parse to create XML objects).
     // No need to do this multiple times.
@@ -914,13 +914,13 @@ int Agent::RegisterForXMLEvent(smlXMLEventId id, XMLEventHandler handler, void* 
     {
         GetKernel()->RegisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     // Record the handler
     m_CallbackIDCounter++ ;
-    
+
     XMLEventHandlerPlusData handlerPlus(id, handler, pUserData, m_CallbackIDCounter) ;
     m_XMLEventMap.add(id, handlerPlus, addToBack) ;
-    
+
     // Return the ID.  We use this later to unregister the callback
     return m_CallbackIDCounter ;
 }
@@ -929,25 +929,25 @@ bool Agent::UnregisterForXMLEvent(int callbackID)
 {
     // Build a test object for the callbackID we're interested in
     TestXMLCallback test(callbackID) ;
-    
+
     // Find the event ID for this callbackID
     smlXMLEventId id = m_XMLEventMap.findFirstKeyByTest(&test, smlXML_EVENT_BAD) ;
-    
+
     if (id == smlXML_EVENT_BAD)
     {
         return false ;
     }
-    
+
     // Remove the handler from our map
     m_XMLEventMap.removeAllByTest(&test) ;
-    
+
     // If we just removed the last handler, then unregister
     // for the matching print event (that we use to implement XML)
     if (m_XMLEventMap.getListSize(id) == 0)
     {
         GetKernel()->UnregisterForEventWithKernel(id, GetAgentName()) ;
     }
-    
+
     return true ;
 }
 
@@ -971,12 +971,12 @@ WMElement* Agent::GetOutputLinkChange(int index)
 {
     OutputDeltaList* pDeltas = GetWM()->GetOutputLinkChanges() ;
     WMDelta* pDelta = pDeltas->GetDeltaWME(index) ;
-    
+
     if (!pDelta)
     {
         return NULL ;
     }
-    
+
     return pDelta->getWME() ;
 }
 
@@ -984,14 +984,14 @@ bool Agent::IsOutputLinkChangeAdd(int index)
 {
     OutputDeltaList* pDeltas = GetWM()->GetOutputLinkChanges() ;
     WMDelta* pDelta = pDeltas->GetDeltaWME(index) ;
-    
+
     if (!pDelta)
     {
         return false ;
     }
-    
+
     bool isAddition = (pDelta->getChangeType() == WMDelta::kAdded) ;
-    
+
     return isAddition ;
 }
 
@@ -1005,24 +1005,24 @@ int Agent::GetNumberCommands()
     // Method is to search all top level output link wmes and see which have
     // just been added and are identifiers.
     int count = 0 ;
-    
+
     Identifier* pOutputLink = GetOutputLink() ;
-    
+
     if (!pOutputLink)
     {
         return 0 ;
     }
-    
+
     for (Identifier::ChildrenIter iter = pOutputLink->GetChildrenBegin() ; iter != pOutputLink->GetChildrenEnd() ; iter++)
     {
         WMElement* pWME = *iter ;
-        
+
         if (pWME->IsIdentifier() && pWME->IsJustAdded())
         {
             count++ ;
         }
     }
-    
+
     return count ;
 }
 
@@ -1031,16 +1031,16 @@ Identifier* Agent::GetCommand(int index)
     // Method is to search all top level output link wmes and see which have
     // just been added and are identifiers.
     Identifier* pOutputLink = GetOutputLink() ;
-    
+
     if (!pOutputLink)
     {
         return NULL ;
     }
-    
+
     for (Identifier::ChildrenIter iter = pOutputLink->GetChildrenBegin() ; iter != pOutputLink->GetChildrenEnd() ; iter++)
     {
         WMElement* pWME = *iter ;
-        
+
         if (pWME->IsIdentifier() && pWME->IsJustAdded())
         {
             if (index == 0)
@@ -1050,7 +1050,7 @@ Identifier* Agent::GetCommand(int index)
             index-- ;
         }
     }
-    
+
     return NULL ;
 }
 
@@ -1060,7 +1060,7 @@ StringElement* Agent::CreateStringWME(Identifier* parent, char const* pAttribute
     {
         return NULL ;
     }
-    
+
     return GetWM()->CreateStringWME(parent, pAttribute, pValue) ;
 }
 
@@ -1070,7 +1070,7 @@ Identifier* Agent::CreateIdWME(Identifier* parent, char const* pAttribute)
     {
         return NULL ;
     }
-    
+
     return GetWM()->CreateIdWME(parent, pAttribute) ;
 }
 
@@ -1080,7 +1080,7 @@ Identifier* Agent::CreateSharedIdWME(Identifier* parent, char const* pAttribute,
     {
         return NULL ;
     }
-    
+
     return GetWM()->CreateSharedIdWME(parent, pAttribute, pSharedValue) ;
 }
 
@@ -1090,7 +1090,7 @@ IntElement* Agent::CreateIntWME(Identifier* parent, char const* pAttribute, long
     {
         return NULL ;
     }
-    
+
     return GetWM()->CreateIntWME(parent, pAttribute, value) ;
 }
 
@@ -1100,7 +1100,7 @@ FloatElement* Agent::CreateFloatWME(Identifier* parent, char const* pAttribute, 
     {
         return NULL ;
     }
-    
+
     return GetWM()->CreateFloatWME(parent, pAttribute, value) ;
 }
 
@@ -1123,7 +1123,7 @@ bool Agent::DestroyWME(WMElement* pWME)
     {
         return false ;
     }
-    
+
     return GetWM()->DestroyWME(pWME) ;
 }
 
@@ -1146,9 +1146,9 @@ char const* Agent::InitSoar()
 {
     // Must commit everything before doing an init-soar.
     assert(!GetWM()->IsCommitRequired()) ;
-    
+
     std::string cmd = "init-soar" ;
-    
+
     // Execute the command.
     // The init-soar causes an event to be sent back from the kernel and when
     // we get that, we'll queue up the input link information to be sent over again
@@ -1161,7 +1161,7 @@ char const* Agent::InitSoar()
 char const* Agent::StopSelf()
 {
     std::string cmd = "stop-soar --self" ;
-    
+
     // Execute the command.
     char const* pResult = ExecuteCommandLine(cmd.c_str()) ;
     return pResult ;
@@ -1174,7 +1174,7 @@ char const* Agent::RunSelf(int numberSteps, smlRunStepSize stepSize)
         assert(false) ;
         return "Need to commit changes before calling a run method" ;
     }
-    
+
 #ifdef SML_DIRECT
     if (GetConnection()->IsDirectConnection())
     {
@@ -1183,15 +1183,15 @@ char const* Agent::RunSelf(int numberSteps, smlRunStepSize stepSize)
         return "DirectRun completed" ;
     }
 #endif
-    
+
     // Convert int to a string
     std::ostringstream ostr ;
     ostr << numberSteps ;
-    
+
     // Create the command line for the run command
     // Create the command line for the run command
     std::string step ;
-    
+
     switch (stepSize)
     {
         case sml_DECISION:
@@ -1209,9 +1209,9 @@ char const* Agent::RunSelf(int numberSteps, smlRunStepSize stepSize)
         default:
             return "Unrecognized step size parameter passed to RunSelf" ;
     }
-    
+
     std::string cmd = "run --self " + step + " " + ostr.str() ;
-    
+
     // Execute the run command.
     char const* pResult = ExecuteCommandLine(cmd.c_str()) ;
     return pResult ;
@@ -1224,7 +1224,7 @@ char const* Agent::RunSelfForever()
         assert(false) ;
         return "Need to commit changes before calling a run method" ;
     }
-    
+
 #ifdef SML_DIRECT
     if (GetConnection()->IsDirectConnection())
     {
@@ -1233,10 +1233,10 @@ char const* Agent::RunSelfForever()
         return "DirectRun completed" ;
     }
 #endif
-    
+
     // Create the command line for the run command
     std::string cmd = "run --self" ;
-    
+
     // Execute the run command.
     char const* pResult = ExecuteCommandLine(cmd.c_str()) ;
     return pResult ;
@@ -1245,14 +1245,14 @@ char const* Agent::RunSelfForever()
 bool Agent::WasAgentOnRunList()
 {
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_WasAgentOnRunList, GetAgentName()) ;
-    
+
     if (!ok)
     {
         return false ;
     }
-    
+
     bool wasRun = response.GetResultBool(false) ;
     return wasRun ;
 }
@@ -1260,16 +1260,16 @@ bool Agent::WasAgentOnRunList()
 smlRunResult Agent::GetResultOfLastRun()
 {
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_GetResultOfLastRun, GetAgentName()) ;
-    
+
     if (!ok)
     {
         return sml_RUN_ERROR ;
     }
-    
+
     smlRunResult result = smlRunResult(response.GetResultInt(int(sml_RUN_ERROR))) ;
-    
+
     return result ;
 }
 
@@ -1290,7 +1290,7 @@ char const* Agent::RunSelfTilOutput()
         assert(false) ;
         return "Need to commit changes before calling a run method" ;
     }
-    
+
 #ifdef SML_DIRECT
     if (GetConnection()->IsDirectConnection())
     {
@@ -1299,12 +1299,12 @@ char const* Agent::RunSelfTilOutput()
         return "DirectRun completed" ;
     }
 #endif
-    
+
     // Run this agent until it generates output.
     // For now, maxDecisions is being ignored.  We should make this a separate call
     // to set this parameter.
     std::string cmd = "run --self --output" ;
-    
+
     return ExecuteCommandLine(cmd.c_str()) ;
 }
 
@@ -1315,51 +1315,51 @@ void Agent::Refresh()
     // as all working memory changes should be committed before other user-input (e.g. init-soar)
     // can be called.
     assert(!IsCommitRequired()) ;
-    
+
     GetWM()->Refresh() ;
 }
 
 smlPhase Agent::GetCurrentPhase()
 {
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_GetRunState, GetAgentName(), sml_Names::kParamValue, sml_Names::kParamPhase) ;
-    
+
     if (!ok)
     {
         return sml_INPUT_PHASE ;
     }
-    
+
     smlPhase phase = smlPhase(response.GetResultInt(int(sml_INPUT_PHASE))) ;
-    
+
     return phase ;
 }
 
 int Agent::GetDecisionCycleCounter()
 {
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_GetRunState, GetAgentName(), sml_Names::kParamValue, sml_Names::kParamDecision) ;
-    
+
     if (!ok)
     {
         return 0 ;
     }
-    
+
     return response.GetResultInt(0) ;
 }
 
 smlRunState Agent::GetRunState()
 {
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_GetRunState, GetAgentName(), sml_Names::kParamValue, sml_Names::kParamRunState) ;
-    
+
     if (!ok)
     {
         return smlRunState(0) ;
     }
-    
+
     return smlRunState(response.GetResultInt(0)) ;
 }
 
@@ -1384,16 +1384,16 @@ bool Agent::IsProductionLoaded(char const* pProductionName)
     {
         return false ;
     }
-    
+
     AnalyzeXML response ;
-    
+
     bool ok = GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_IsProductionLoaded, GetAgentName(), sml_Names::kParamName, pProductionName) ;
-    
+
     if (!ok)
     {
         return false ;
     }
-    
+
     return response.GetResultBool(false) ;
 }
 
@@ -1453,27 +1453,27 @@ bool Agent::SpawnDebugger(int port, const char* jarpath)
         }
         p = h;
     }
-    
+
     if (port == -1)
     {
         port = m_Kernel->GetListenerPort();
     }
-    
+
     if (m_pDPI)
     {
         return false;
     }
     m_pDPI = new DebuggerProcessInformation();
-    
+
 #ifdef _WIN32
     ZeroMemory(&m_pDPI->debuggerStartupInfo, sizeof(m_pDPI->debuggerStartupInfo));
     m_pDPI->debuggerStartupInfo.cb = sizeof(m_pDPI->debuggerStartupInfo);
     ZeroMemory(&m_pDPI->debuggerProcessInformation, sizeof(m_pDPI->debuggerProcessInformation));
-    
+
     // Start the child process.
     std::stringstream commandLine;
     commandLine << "javaw.exe -jar \"" << p << "\" -remote -port " << port << " -agent \"" << this->GetAgentName() << "\"";
-    
+
     BOOL ret = CreateProcess(
                    0,
                    const_cast< LPSTR >(commandLine.str().c_str()),      // Command line
@@ -1485,7 +1485,7 @@ bool Agent::SpawnDebugger(int port, const char* jarpath)
                    0,                              // Use parent's starting directory
                    &m_pDPI->debuggerStartupInfo,           // Pointer to STARTUPINFO structure
                    &m_pDPI->debuggerProcessInformation);   // Pointer to PROCESS_INFORMATION structure
-                   
+
     if (ret == 0)
     {
         std::cout << "Error code: " << GetLastError() << std::endl;
@@ -1494,7 +1494,7 @@ bool Agent::SpawnDebugger(int port, const char* jarpath)
         return false;
     }
     return true;
-    
+
 #else // _WIN32
     m_pDPI->debuggerPid = fork();
     if (m_pDPI->debuggerPid < 0)
@@ -1503,13 +1503,13 @@ bool Agent::SpawnDebugger(int port, const char* jarpath)
         m_pDPI = 0;
         return false;
     }
-    
+
     if (m_pDPI->debuggerPid == 0)
     {
         // child
         std::string portstring;
         to_string(port, portstring);
-    
+
 #if (defined(__APPLE__) && defined(__MACH__))
         execlp("java", "java", "-XstartOnFirstThread", "-jar", p.c_str(), "-remote",
                "-port", portstring.c_str(), "-agent", this->GetAgentName(), NULL);
@@ -1518,11 +1518,11 @@ bool Agent::SpawnDebugger(int port, const char* jarpath)
                "-port", portstring.c_str(), "-agent", this->GetAgentName(), NULL);
 #endif
         // does not return on success
-    
+
         std::cerr << "Debugger spawn failed: " << strerror(errno) << std::endl;
         exit(1);
     }
-    
+
     // parent
     return true;
 #endif // _WIN32
@@ -1535,7 +1535,7 @@ bool Agent::KillDebugger()
         return false;
     }
     bool successful = false;
-    
+
 #ifdef _WIN32
     // Wait until child process exits.
     BOOL ret = TerminateProcess(m_pDPI->debuggerProcessInformation.hProcess, 0);
@@ -1545,14 +1545,14 @@ bool Agent::KillDebugger()
     {
         successful = true;
     }
-    
+
 #else // _WIN32
     if (!kill(m_pDPI->debuggerPid, SIGTERM))
     {
         successful = true;
     }
 #endif // _WIN32
-    
+
     delete m_pDPI;
     m_pDPI = 0;
     return successful;
@@ -1563,12 +1563,12 @@ char const* Agent::ConvertIdentifier(char const* pClientIdentifier)
     // need to keep the result around after the function returns
     // bad
     static std::string kernelIdentifier;
-    
+
     AnalyzeXML response;
-    
+
     // Send the command to the kernel
     bool ret = m_Kernel->GetConnection()->SendAgentCommand(&response, sml_Names::kCommand_ConvertIdentifier, GetAgentName(), sml_Names::kParamName, pClientIdentifier);
-    
+
     if (ret)
     {
         // Get the result as a string
@@ -1582,6 +1582,7 @@ char const* Agent::ConvertIdentifier(char const* pClientIdentifier)
     return pClientIdentifier;
 }
 
+#ifndef NO_SVS
 void Agent::SendSVSInput(const std::string& txt)
 {
     GetKernel()->SendSVSInput(GetAgentName(), txt);
@@ -1596,3 +1597,4 @@ std::string Agent::GetSVSOutput()
 {
     return GetKernel()->GetSVSOutput(GetAgentName());
 }
+#endif

--- a/Core/ClientSML/src/sml_ClientAgent.h
+++ b/Core/ClientSML/src/sml_ClientAgent.h
@@ -36,96 +36,96 @@ namespace sml
     class ClientXML ;
     class ClientAnalyzedXML ;
     struct DebuggerProcessInformation;
-    
+
     class RunEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             RunEventHandler m_Handler ;
-            
+
             RunEventHandlerPlusData() {}
-            
+
             RunEventHandlerPlusData(int eventID, RunEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class ProductionEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             ProductionEventHandler m_Handler ;
-            
+
             ProductionEventHandlerPlusData() {}
-            
+
             ProductionEventHandlerPlusData(int eventID, ProductionEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class PrintEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             PrintEventHandler m_Handler ;
             bool m_IgnoreOwnEchos ;
-            
+
             PrintEventHandlerPlusData()
             {
                 m_IgnoreOwnEchos = true;
             }
-            
+
             PrintEventHandlerPlusData(int eventID, PrintEventHandler handler, void* userData, bool ignoreOwnEchos, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
                 m_IgnoreOwnEchos = ignoreOwnEchos ;
             }
     } ;
-    
+
     class XMLEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             XMLEventHandler m_Handler ;
-            
+
             XMLEventHandlerPlusData() {}
-            
+
             XMLEventHandlerPlusData(int eventID, XMLEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class OutputEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             OutputEventHandler  m_Handler ;
             std::string         m_AttributeName ;
-            
+
             OutputEventHandlerPlusData() {}
-            
+
             OutputEventHandlerPlusData(int eventID, char const* pAttributeName, OutputEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
-                
+
                 if (pAttributeName)
                 {
                     m_AttributeName = pAttributeName ;
                 }
             }
     } ;
-    
+
     class OutputNotificationHandlerPlusData : public EventHandlerPlusData
     {
         public:
             OutputNotificationHandler   m_Handler ;
-            
+
             OutputNotificationHandlerPlusData() {}
-            
+
             OutputNotificationHandlerPlusData(int eventID, OutputNotificationHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class EXPORT Agent : public ClientErrors
     {
             // By using a lot of friends we can keep methods from being exposed
@@ -138,7 +138,7 @@ namespace sml
             friend class IntElement ;
             friend class FloatElement ;
             friend class Identifier ;
-            
+
         protected:
             // The mapping from event number to a list of handlers to call when that event fires
             typedef sml::ListMap<smlRunEventId, RunEventHandlerPlusData>                RunEventMap ;
@@ -147,17 +147,17 @@ namespace sml
             typedef sml::ListMap<smlXMLEventId, XMLEventHandlerPlusData>                XMLEventMap ;
             typedef sml::ListMap<std::string, OutputEventHandlerPlusData>               OutputEventMap ;
             typedef sml::ListMap<smlWorkingMemoryEventId, OutputNotificationHandlerPlusData>    OutputNotificationMap ;
-            
+
         protected:
             // We maintain a local copy of working memory so we can just send changes
             WorkingMemory   m_WorkingMemory ;
-            
+
             // The kernel that owns this agent
             Kernel*         m_Kernel ;
-            
+
             // The name of this agent
             std::string     m_Name ;
-            
+
             // Map from event id to handler function(s)
             RunEventMap             m_RunEventMap ;
             ProductionEventMap      m_ProductionEventMap ;
@@ -165,7 +165,7 @@ namespace sml
             XMLEventMap             m_XMLEventMap ;
             OutputEventMap          m_OutputEventMap ;
             OutputNotificationMap   m_OutputNotificationMap ;
-            
+
             // These are little utility classes we define in the .cpp file to help with searching the event maps
             class TestRunCallbackFull ;
             class TestRunCallback ;
@@ -179,30 +179,30 @@ namespace sml
             class TestOutputCallback ;
             class TestOutputNotificationCallbackFull ;
             class TestOutputNotificationCallback ;
-            
+
             // Used to generate unique IDs for callbacks
             int m_CallbackIDCounter ;
-            
+
             // Internally we register a print callback and store its id here.
             int m_XMLCallback ;
-            
+
             // When true, if a wme is updated to the same value as before we "blink" the wme by removing
             // the old wme and adding a new one, causing rules to rematch in Soar.
             bool m_BlinkIfNoChange ;
-            
+
         protected:
             Agent(Kernel* pKernel, char const* pAgentName);
-            
+
             // This is protected so the client doesn't try to delete it.
             // Client should just delete the kernel object (or call Kernel::DestroyAgent() if just want to destroy this agent).
             virtual ~Agent();
-            
+
             Connection* GetConnection() const ;
             WorkingMemory* GetWM()
             {
                 return &m_WorkingMemory ;
             }
-            
+
             /*************************************************************
             * @brief This function is called when output is received
             *        from the Soar kernel.
@@ -211,7 +211,7 @@ namespace sml
             * @param pResponse  The reply (no real need to fill anything in here currently)
             *************************************************************/
             void ReceivedOutput(AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             /*************************************************************
             * @brief This function is called when an event is received
             *        from the Soar kernel.
@@ -224,16 +224,16 @@ namespace sml
             void ReceivedProductionEvent(smlProductionEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             void ReceivedPrintEvent(smlPrintEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             void ReceivedXMLEvent(smlXMLEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             /** NOTE: Slightly different sig as this is called without analyzing the incoming msg so it's a bit faster */
             void ReceivedXMLTraceEvent(smlXMLEventId id, soarxml::ElementXML* pIncomingMsg, soarxml::ElementXML* pResponse) ;
-            
+
             /*************************************************************
             * @brief This function is called after output has been received
             *        and processed from the kernel.
             *************************************************************/
             void FireOutputNotification() ;
-            
+
             /*************************************************************
             * @brief Call any registered handlers to notify them when
             *        a new working memory element is added to the top
@@ -241,14 +241,14 @@ namespace sml
             *************************************************************/
             void ReceivedOutputEvent(WMElement* pWmeAdded) ;
             bool IsRegisteredForOutputEvent() ;
-            
+
             /*************************************************************
             * @brief Returns true if changes to i/o links should be
             *        committed (sent to kernelSML) immediately when they
             *        occur, so the client doesn't need to remember to call commit.
             *************************************************************/
             bool IsAutoCommitEnabled() ;
-            
+
         public:
             /*************************************************************
             * @brief Returns this agent's name.
@@ -257,7 +257,7 @@ namespace sml
             {
                 return m_Name.c_str() ;
             }
-            
+
             /*************************************************************
             * @brief Returns a pointer to the kernel object that owns this Agent.
             *************************************************************/
@@ -265,7 +265,7 @@ namespace sml
             {
                 return m_Kernel ;
             }
-            
+
             /*************************************************************
             * @brief Load a set of productions from a file.
             *
@@ -277,13 +277,13 @@ namespace sml
             * @returns True if finds file to load successfully.
             *************************************************************/
             bool LoadProductions(char const* pFilename, bool echoResults = true) ;
-            
+
             /*************************************************************
             * @brief Returns the id object for the input link.
             *        The agent retains ownership of this object.
             *************************************************************/
             Identifier* GetInputLink() ;
-            
+
             /*************************************************************
             * @brief An alternative that matches the older SGIO interface.
             *        The agent retains ownership of this object.
@@ -292,7 +292,7 @@ namespace sml
             {
                 return GetInputLink() ;
             }
-            
+
             /*************************************************************
             * @brief Returns the id object for the output link.
             *        The agent retains ownership of this object.
@@ -300,7 +300,7 @@ namespace sml
             *        puts something on the output link.
             *************************************************************/
             Identifier* GetOutputLink() ;
-            
+
             /*************************************************************
             * @brief Builds a new WME that has a string value and schedules
             *        it for addition to Soar's input link.
@@ -324,7 +324,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             StringElement* CreateStringWME(Identifier* parent, char const* pAttribute, char const* pValue);
-            
+
             /*************************************************************
             * @brief Same as CreateStringWME but for a new WME that has
             *        an int as its value.
@@ -339,7 +339,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             IntElement* CreateIntWME(Identifier* parent, char const* pAttribute, long long value) ;
-            
+
             /*************************************************************
             * @brief Same as CreateStringWME but for a new WME that has
             *        a floating point value.
@@ -354,7 +354,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             FloatElement* CreateFloatWME(Identifier* parent, char const* pAttribute, double value) ;
-            
+
             /*************************************************************
             * @brief Same as CreateStringWME but for a new WME that has
             *        an identifier as its value.
@@ -372,7 +372,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             Identifier*     CreateIdWME(Identifier* parent, char const* pAttribute) ;
-            
+
             /*************************************************************
             * @brief Creates a new WME that has an identifier as its value.
             *        The value in this case is the same as an existing identifier.
@@ -388,7 +388,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             Identifier*     CreateSharedIdWME(Identifier* parent, char const* pAttribute, Identifier* pSharedValue) ;
-            
+
             /*************************************************************
             * @brief Update the value of an existing WME.
             *        If "auto commit" is turned off in ClientKernel,
@@ -414,7 +414,7 @@ namespace sml
             void    Update(StringElement* pWME, char const* pValue) ;
             void    Update(IntElement* pWME, long long value) ;
             void    Update(FloatElement* pWME, double value) ;
-            
+
             /*************************************************************
             * @brief This flag controls whether updating a wme to the same
             *        value that it already has causes it to "blink" or not.
@@ -429,7 +429,7 @@ namespace sml
             {
                 return m_BlinkIfNoChange ;
             }
-            
+
             /*************************************************************
             * @brief Schedules a WME from deletion from the input link and removes
             *        it from the client's model of working memory.
@@ -453,7 +453,7 @@ namespace sml
             *        a removed WME causes a segmentation fault.
             *************************************************************/
             bool    DestroyWME(WMElement* pWME) ;
-            
+
             /*************************************************************
             * @brief Reinitialize this Soar agent.
             *        This will also cause the output link structures stored
@@ -461,7 +461,7 @@ namespace sml
             *        to the Soar agent for the start of its next run.
             *************************************************************/
             char const* InitSoar() ;
-            
+
             /*************************************************************
             * @brief Register an "Output event handler".
             *        This is one way to be notified when output occurs on the output link.
@@ -475,12 +475,12 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int AddOutputHandler(char const* pAttributeName, OutputEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular output event
             *************************************************************/
             bool RemoveOutputHandler(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for a "RunEvent".
             *        Multiple handlers can be registered for the same event.
@@ -508,12 +508,12 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForRunEvent(smlRunEventId id, RunEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             *************************************************************/
             bool    UnregisterForRunEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register to be notified when output has been received from the agent.
             *        This event is a bit special, because we ensure that the client side data structures
@@ -522,7 +522,7 @@ namespace sml
             *************************************************************/
             int RegisterForOutputNotification(OutputNotificationHandler handler, void* pUserData, bool addToBack = true) ;
             bool UnregisterForOutputNotification(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for a "ProductionEvent".
             *        Multiple handlers can be registered for the same event.
@@ -541,12 +541,12 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForProductionEvent(smlProductionEventId id, ProductionEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             *************************************************************/
             bool    UnregisterForProductionEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for an "PrintEvent".
             *        Multiple handlers can be registered for the same event.
@@ -562,12 +562,12 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForPrintEvent(smlPrintEventId id, PrintEventHandler handler, void* pUserData, bool ignoreOwnEchos = true, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             *************************************************************/
             bool UnregisterForPrintEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for an "XMLEvent".
             *        Multiple handlers can be registered for the same event.
@@ -582,12 +582,12 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForXMLEvent(smlXMLEventId id, XMLEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             *************************************************************/
             bool UnregisterForXMLEvent(int callbackID) ;
-            
+
             /*==============================================================================
             ===
             === There are a number of different ways to read information from
@@ -629,7 +629,7 @@ namespace sml
             === the list of commands is known in advance (usually not a problem).
             ===
             ==============================================================================*/
-            
+
             /*************************************************************
             * @brief Enable or disable output-link change tracking. Do
             *        NOT use if using Commands, GetCommand,
@@ -639,25 +639,25 @@ namespace sml
             {
                 GetWM()->SetOutputLinkChangeTracking(setting);
             }
-            
+
             /*************************************************************
             * @brief Get number of changes to output link since last cycle.
             *************************************************************/
             int     GetNumberOutputLinkChanges() ;
-            
+
             /*************************************************************
             * @brief Get the n-th wme added or deleted to output link since
             *        last cycle.
             *************************************************************/
             WMElement*  GetOutputLinkChange(int index) ;
-            
+
             /*************************************************************
             * @brief Returns true if the n-th wme change to the output-link
             *        since the last cycle was a wme being added.
             *        (false => it was a wme being deleted)
             *************************************************************/
             bool        IsOutputLinkChangeAdd(int index) ;
-            
+
             /*************************************************************
             * @brief Deprecated: Clears the current list of changes
             *        to the output-link.
@@ -665,7 +665,7 @@ namespace sml
             *        decision cycle.
             *************************************************************/
             void    ClearOutputLinkChanges() ;
-            
+
             /*************************************************************
             * @brief Get the number of "commands".  A command in this context
             *        is an identifier wme that have been added to the top level of
@@ -675,7 +675,7 @@ namespace sml
             *        best to not call it repeatedly.
             *************************************************************/
             int     GetNumberCommands() ;
-            
+
             /*************************************************************
             * @brief Returns true if there are "commands" available.
             *        A command in this context is an identifier wme that
@@ -689,7 +689,7 @@ namespace sml
             {
                 return GetNumberCommands() > 0 ;
             }
-            
+
             /*************************************************************
             * @brief Get the n-th "command".  A command in this context
             *        is an identifier wme that have been added to the top level of
@@ -709,18 +709,18 @@ namespace sml
             * @param index  The 0-based index for which command to get.
             *************************************************************/
             Identifier* GetCommand(int index) ;
-            
+
             /*************************************************************
             * @brief Send the most recent list of changes to working memory
             *        over to the kernel.
             *************************************************************/
             bool Commit() ;
-            
+
             /*************************************************************
             * @brief Returns true if this agent has uncommitted changes.
             *************************************************************/
             bool IsCommitRequired() ;
-            
+
             /*************************************************************
             * @brief   Run one Soar agent for the specified number of decisions
             *
@@ -729,7 +729,7 @@ namespace sml
             *************************************************************/
             char const* RunSelf(int numberSteps, smlRunStepSize stepSize = sml_DECISION) ;
             char const* RunSelfForever() ;
-            
+
             /*************************************************************
             * @brief   Run Soar until either output is generated or
             *          the maximum number of decisions is reached.
@@ -742,19 +742,19 @@ namespace sml
             * max-nil-output-cycles command).
             *************************************************************/
             char const* RunSelfTilOutput() ;
-            
+
             /*************************************************************
             * @brief Returns true if this agent was part of the last set
             *        of agents that was run.
             *************************************************************/
             bool WasAgentOnRunList() ;
-            
+
             /*************************************************************
             * @brief Returns whether the last run for this agent was
             *        interrupted (by a stop call) or completed normally.
             *************************************************************/
             smlRunResult GetResultOfLastRun() ;
-            
+
             /*************************************************************
             * @brief Interrupt the currently running Soar agent.
             *
@@ -769,7 +769,7 @@ namespace sml
             *
             *************************************************************/
             char const* StopSelf() ;
-            
+
             /*************************************************************
             * @brief Resend the complete input link to the kernel
             *        and remove our output link structures.
@@ -777,24 +777,24 @@ namespace sml
             *        There should be no reason for the client to call this method directly.
             *************************************************************/
             void Refresh() ;
-            
+
             /*************************************************************
             * @brief Returns the phase that the agent will execute when next
             *        asked to run.
             *************************************************************/
             smlPhase GetCurrentPhase() ;
-            
+
             /*************************************************************
             * @brief Returns the current decision cycle counter.
             *************************************************************/
             int GetDecisionCycleCounter() ;
-            
+
             /*************************************************************
             * @brief Returns the current run state of the agent.
             *        Mostly of use to determine if agent halted in last run.
             *************************************************************/
             smlRunState GetRunState() ;
-            
+
             /*************************************************************
             * @brief Process a command line command
             *
@@ -804,7 +804,7 @@ namespace sml
             * @returns The string form of output from the command.
             *************************************************************/
             char const* ExecuteCommandLine(char const* pCommandLine, bool echoResults = false, bool noFilter = false) ;
-            
+
             /*************************************************************
             * @brief Execute a command line command and return the result
             *        as an XML object.
@@ -816,11 +816,13 @@ namespace sml
             * @returns True if the command succeeds.
             *************************************************************/
             bool ExecuteCommandLineXML(char const* pCommandLine, ClientAnalyzedXML* pResponse) ;
-            
+
+#ifndef NO_SVS
             void        SendSVSInput(const std::string& txt);
             std::string GetSVSOutput();
             std::string SVSQuery(const std::string& q);
-            
+#endif
+
             /*************************************************************
             * @brief Get last command line result
             *
@@ -830,13 +832,13 @@ namespace sml
             * @returns True if the last command line call succeeded.
             *************************************************************/
             bool GetLastCommandLineResult();
-            
+
             /*************************************************************
             * @brief Returns true if this string is the name of a production
             *        that is currently loaded in the agent.
             *************************************************************/
             bool IsProductionLoaded(char const* pProductionName) ;
-            
+
             /*************************************************************
             * @brief This method is used to update this client's representation
             *        of the input link to match what is currently on the agent's
@@ -851,7 +853,7 @@ namespace sml
             *        make any guarantees about what will or won't work.
             *************************************************************/
             bool SynchronizeInputLink() ;
-            
+
             /*************************************************************
             * @brief This method is used to update this client's representation
             *        of the output link to match what is currently on the agent's
@@ -865,7 +867,7 @@ namespace sml
             *        and wants to get up to date on the current state of the output link.
             *************************************************************/
             bool SynchronizeOutputLink() ;
-            
+
             /*************************************************************
             * @brief This method spawns a debugger to connect to this agent.
             *        Java must be in the path. If jarpath is NULL, the
@@ -874,23 +876,23 @@ namespace sml
             *        false if the jar is not found or process spawning fails.
             *************************************************************/
             bool SpawnDebugger(int port = -1, const char* jarpath = 0);
-            
+
             /*************************************************************
             * @brief Kills the previously spawned debugger.
             *************************************************************/
             bool KillDebugger();
-            
+
             /*************************************************************
             * @brief Convert a client-side identifier string to kernel-side.
             *************************************************************/
             char const* ConvertIdentifier(char const* pClientIdentifier);
-            
+
         protected:
             // for {Spawn, Kill}Debugger()
             DebuggerProcessInformation* m_pDPI;
-            
+
     };
-    
+
 }//closes namespace
 
 #endif //SML_AGENT_H

--- a/Core/ClientSML/src/sml_ClientKernel.h
+++ b/Core/ClientSML/src/sml_ClientKernel.h
@@ -44,78 +44,78 @@ namespace sml
     class Events ;
     class AnalyzeXML ;
     class ClientAnalyzedXML ;
-    
+
     class SystemEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             SystemEventHandler  m_Handler ;
-            
+
             SystemEventHandlerPlusData() {}
-            
+
             SystemEventHandlerPlusData(int eventID, SystemEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class UpdateEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             UpdateEventHandler  m_Handler ;
-            
+
             UpdateEventHandlerPlusData() {}
-            
+
             UpdateEventHandlerPlusData(int eventID, UpdateEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class StringEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             StringEventHandler  m_Handler ;
-            
+
             StringEventHandlerPlusData() {}
-            
+
             StringEventHandlerPlusData(int eventID, StringEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class AgentEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             AgentEventHandler m_Handler ;
-            
+
             AgentEventHandlerPlusData() {}
-            
+
             AgentEventHandlerPlusData(int eventID, AgentEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
             }
     } ;
-    
+
     class RhsEventHandlerPlusData : public EventHandlerPlusData
     {
         public:
             RhsEventHandler m_Handler ;
             std::string     m_FunctionName ;
-            
+
             RhsEventHandlerPlusData() {}
-            
+
             RhsEventHandlerPlusData(int eventID, char const* pFunctionName, RhsEventHandler handler, void* userData, int callbackID) : EventHandlerPlusData(eventID, userData, callbackID)
             {
                 m_Handler = handler ;
-                
+
                 if (pFunctionName)
                 {
                     m_FunctionName = pFunctionName ;
                 }
             }
     } ;
-    
+
     class ConnectionInfo
     {
         protected:
@@ -123,7 +123,7 @@ namespace sml
             std::string m_Name ;
             std::string m_Status ;
             std::string m_AgentStatus ;
-            
+
         public:
             ConnectionInfo(char const* pID, char const* pName, char const* pStatus, char const* pAgentStatus)
             {
@@ -132,38 +132,38 @@ namespace sml
                 m_Status = (pStatus ? pStatus : "unknown-status") ;
                 m_AgentStatus = (pAgentStatus ? pAgentStatus : "unknown-status") ;
             }
-            
+
             /** The ID is a unique identifier for this connection (machine created) */
             char const* GetID() const
             {
                 return m_ID.c_str() ;
             }
-            
+
             /** The name may be set by the owner of the connection (or not) */
             char const* GetName() const
             {
                 return m_Name.c_str() ;
             }
-            
+
             /** The connection status is a string from a known set of values, again set by the owner of the connection */
             char const* GetConnectionStatus() const
             {
                 return m_Status.c_str() ;
             }
-            
+
             /** The agent status is a string from a known set of values, again set by the owner of the connection and refers to the most recently created agent */
             char const* GetAgentStatus() const
             {
                 return m_AgentStatus.c_str() ;
             }
     } ;
-    
+
     class EXPORT Kernel : public ClientErrors
     {
             // Allow the agent to call to get the connection from the kernel.
             friend class Agent ;
             friend class WorkingMemory ;    // Access to generate next ID methods
-            
+
         public:
             enum
             {
@@ -171,43 +171,43 @@ namespace sml
                 kSuppressListener = 0,
                 kUseAnyPort = -1,
             } ;
-            
+
         protected:
             long long       m_TimeTagCounter ;  // Used to generate time tags (we do them in the kernel not the agent, so ids are unique for all agents)
             long long       m_IdCounter ;       // Used to generate unique id names
             int         m_CallbackIDCounter ;   // Used to generate unique callback IDs
-            
+
             // The mapping from event number to a list of handlers to call when that event fires
             typedef sml::ListMap<smlSystemEventId, SystemEventHandlerPlusData>          SystemEventMap ;
             typedef sml::ListMap<smlAgentEventId, AgentEventHandlerPlusData>            AgentEventMap ;
             typedef sml::ListMap<std::string, RhsEventHandlerPlusData>                  RhsEventMap ;
             typedef sml::ListMap<smlUpdateEventId, UpdateEventHandlerPlusData>          UpdateEventMap ;
             typedef sml::ListMap<smlStringEventId, StringEventHandlerPlusData>          StringEventMap ;
-            
+
             Connection*         m_Connection ;
             ObjectMap<Agent*>   m_AgentMap ;
             std::string         m_CommandLineResult;
             bool                m_CommandLineSucceeded ;
             sock::SocketLib*    m_SocketLibrary ;
-            
+
             // Info about all connections (have to explicitly request this)
             std::list<ConnectionInfo*> m_ConnectionInfoList ;
             typedef std::list<ConnectionInfo*>::iterator ConnectionListIter ;
             bool                m_ConnectionInfoChanged ;
-            
+
             // When true, commands are sent to external filters (if they are registered) for filtering before execution.
             bool                m_FilteringEnabled ;
-            
+
             // Which handler functions to call when an event comes in
             SystemEventMap      m_SystemEventMap ;
             AgentEventMap       m_AgentEventMap ;
             RhsEventMap         m_RhsEventMap ;
             UpdateEventMap      m_UpdateEventMap ;
             StringEventMap      m_StringEventMap ;
-            
+
             // Class used to map events ids to and from strings
             Events*             m_pEventMap ;
-            
+
             // Utility classes used to test for values in the event maps
             class TestSystemCallbackFull ;
             class TestSystemCallback ;
@@ -219,54 +219,54 @@ namespace sml
             class TestUpdateCallback ;
             class TestStringCallbackFull ;
             class TestStringCallback ;
-            
+
             // Keep a local copy of this flag so we can report
             // information directly about what the client is sending/receiving
             bool m_bTracingCommunications ;
             bool m_bShutdown ;
-            
+
             // If true, don't register to get output link events
             bool m_bIgnoreOutput ;
-            
+
             // If true, commit all changes to working memory immediately after they occur
             // (that is send them over to kernelSML immediately, rather than collecting them up for a single commit)
             bool m_bAutoCommit ;
-            
+
             // This thread is used to check for incoming events when the client goes to sleep
             // It ensures the client stays "alive" and is optional (there are other ways for clients to keep themselves
             // responsive).
             EventThread*        m_pEventThread ;
-            
+
             // To create a kernel object, use one of the static methods, e.g. Kernel::CreateEmbeddedConnection().
             Kernel(Connection* pConnection);
-            
+
             void InitEvents() ;
-            
+
             /*************************************************************
             * @brief Register for a particular event with the kernel.
             *        (This is a primitive function, should call one of the
             *         higher level methods which will call here if needed)
             *************************************************************/
             void    RegisterForEventWithKernel(int id, char const* pAgentName) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event with the kernel.
             *        (This is a primitive function, should call one of the
             *         higher level methods which will call here if needed)
             *************************************************************/
             void    UnregisterForEventWithKernel(int id, char const* pAgentName) ;
-            
+
             /*************************************************************
             * @brief Creates a new Agent* object (not to be confused
             *        with actually creating a Soar agent -- see CreateAgent for that)
             *************************************************************/
             Agent* MakeAgent(char const* pAgentName) ;
-            
+
             void SetSocketLib(sock::SocketLib* pLibrary)
             {
                 m_SocketLibrary = pLibrary ;
             }
-            
+
             long long   GenerateNextID()
             {
                 return ++m_IdCounter ;
@@ -275,13 +275,13 @@ namespace sml
             {
                 return --m_TimeTagCounter ;    // Count down so different from Soar kernel
             }
-            
+
             /***
             ***   RHS functions and message event handlers use the same internal logic, although they look rather different to the user
             ***/
             int InternalAddRhsFunction(smlRhsEventId id, char const* pRhsFunctionName, RhsEventHandler handler, void* pUserData, bool addToBack) ;
             bool InternalRemoveRhsFunction(smlRhsEventId id, int callbackID) ;
-            
+
             /*************************************************************
             * @brief This function is called when an event is received
             *        from the Soar kernel.
@@ -295,7 +295,7 @@ namespace sml
             void ReceivedRhsEvent(smlRhsEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             void ReceivedUpdateEvent(smlUpdateEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             void ReceivedStringEvent(smlStringEventId id, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             /*************************************************************
             * @brief If this message is an XML trace message returns
             *        the agent pointer this message is for.
@@ -304,9 +304,9 @@ namespace sml
             *        which are really performance critical.
             *************************************************************/
             Agent* IsXMLTraceEvent(soarxml::ElementXML* pIncomingMsg) ;
-            
+
             void InitializeTimeTagCounter() ;
-            
+
         public:
             /*************************************************************
             * @brief Creates a connection to the Soar kernel that is embedded
@@ -337,11 +337,11 @@ namespace sml
             *************************************************************/
             static Kernel* CreateKernelInCurrentThread(bool optimized = false, int portToListenOn = kDefaultSMLPort) ;
             static Kernel* CreateKernelInNewThread(int portToListenOn = kDefaultSMLPort) ;
-            
+
             int GetListenerPort();
-            
+
             Soar_Instance* m_SoarInstance;
-            
+
             /*************************************************************
             * @brief Creates a connection to a receiver that is in a different
             *        process.  The process can be on the same machine or a different machine.
@@ -361,7 +361,7 @@ namespace sml
             *          If an error occurs a Kernel object is still returned.  Call "HadError()" and "GetLastErrorDescription()" on it.
             *************************************************************/
             static Kernel* CreateRemoteConnection(bool sharedFileSystem = true, char const* pIPaddress = 0, int port = kDefaultSMLPort, bool ignoreOutput = false) ;
-            
+
             /*************************************************************
             * @brief Returns the default port we use for remote connections.
             *************************************************************/
@@ -369,7 +369,7 @@ namespace sml
             {
                 return kDefaultSMLPort ;
             }
-            
+
             /*************************************************************
             * @brief If auto commit is set to false then after making any changes
             *        to working memory elements (adds, updates, deletes) the client
@@ -391,21 +391,21 @@ namespace sml
             {
                 return m_bAutoCommit ;
             }
-            
+
             /*************************************************************
             * @brief True if our connection to the kernel has been closed.
             *        (Generally used for remote connections)
             *************************************************************/
             bool IsConnectionClosed() ;
-            
+
             /*************************************************************
             * @brief True if this is a remote connection to the kernel
             *        (i.e. connected over a socket rather than by loading a library)
             *************************************************************/
             bool IsRemoteConnection() ;
-            
+
             bool IsDirectConnection() ;
-            
+
             /*************************************************************
             * @brief Preparation for deleting the kernel.
             *        Agents are destroyed at this point (if we own the kernel)
@@ -416,7 +416,7 @@ namespace sml
             *        state (while the kernel object still exists).
             *************************************************************/
             void Shutdown() ;
-            
+
             /*************************************************************
             * @brief Delete the kernel (or our connection to the kernel)
             *        releasing all memory owned by the kernel.
@@ -424,14 +424,14 @@ namespace sml
             *        to ensure a clean shutdown.
             *************************************************************/
             virtual ~Kernel();
-            
+
             /*************************************************************
             * @brief Turning this on means we'll start dumping output about messages
             *        being sent and received.
             *************************************************************/
             void SetTraceCommunications(bool state) ;
             bool IsTracingCommunications() ;
-            
+
             /*************************************************************
             * @brief Creates a new Soar agent with the given name.
             *
@@ -440,19 +440,19 @@ namespace sml
             *          kernel is destroyed.
             *************************************************************/
             Agent* CreateAgent(char const* pAgentName) ;
-            
+
             /*************************************************************
             * @brief Get the list of agents currently active in the kernel
             *        and create local Agent objects for each one (if we
             *        don't already have that agent registered).
             *************************************************************/
             void UpdateAgentList() ;
-            
+
             /*************************************************************
             * @brief Returns the number of agents (from our list of known agents).
             *************************************************************/
             int GetNumberAgents() ;
-            
+
             /*************************************************************
             * @brief Destroys an agent in the kernel (and locally).
             *
@@ -465,7 +465,7 @@ namespace sml
             *        event which is called immediately before the deletion occurs.
             *************************************************************/
             bool DestroyAgent(Agent* pAgent) ;
-            
+
             /*************************************************************
             * @brief Looks up an agent by name (from our list of known agents).
             *
@@ -474,19 +474,19 @@ namespace sml
             *          kernel is destroyed.
             *************************************************************/
             Agent* GetAgent(char const* pAgentName) ;
-            
+
             /*************************************************************
             * @brief Returns the n-th agent from our list of known agents.
             *        This is slower than GetAgent(pAgentName).
             *************************************************************/
             Agent* GetAgentByIndex(int index) ;
-            
+
             /*************************************************************
             * @brief Returns true if this agent pointer is still valid and
             *        can be used.
             *************************************************************/
             bool    IsAgentValid(Agent* pAgent) ;
-            
+
             /*************************************************************
             * @brief If filtering is disabled, that means all commands
             *        sent from this client will not be filtered (sent to
@@ -497,7 +497,7 @@ namespace sml
             *        is available on a command by command basis.
             *************************************************************/
             void    EnableFiltering(bool state) ;
-            
+
             /*************************************************************
             * @brief Process a command line command
             *
@@ -508,7 +508,7 @@ namespace sml
             * @returns The string form of output from the command.
             *************************************************************/
             char const* ExecuteCommandLine(char const* pCommandLine, char const* pAgentName, bool echoResults = false, bool noFilter = false) ;
-            
+
             /*************************************************************
             * @brief Execute a command line command and return the result
             *        as an XML object.
@@ -520,7 +520,7 @@ namespace sml
             * @returns True if the command succeeds.
             *************************************************************/
             bool ExecuteCommandLineXML(char const* pCommandLine, char const* pAgentName, ClientAnalyzedXML* pResponse) ;
-            
+
             /*************************************************************
             * @brief   Run Soar for the specified number of decisions
             *
@@ -535,7 +535,7 @@ namespace sml
             *************************************************************/
             char const* RunAllAgents(int numberSteps, smlRunStepSize stepSize = sml_DECISION, smlRunStepSize interleaveStepSize = sml_PHASE) ;
             char const* RunAllAgentsForever(smlRunStepSize interleaveStepSize = sml_PHASE) ;
-            
+
             /*************************************************************
             * @brief   Run Soar until either output is generated or
             *          the maximum number of decisions is reached.  This is done
@@ -550,7 +550,7 @@ namespace sml
             * max-nil-output-cycles command).
             *************************************************************/
             char const* RunAllTilOutput(smlRunStepSize interleaveStepSize = sml_PHASE) ;
-            
+
             /*************************************************************
             * @brief Interrupt the currently running Soar agent.
             *
@@ -563,7 +563,7 @@ namespace sml
             * Soar will stop at the next point it is considered safe to do so.
             *************************************************************/
             char const* StopAllAgents() ;
-            
+
             /*************************************************************
             * @brief Returns true if one or more agents are currently running.
             *
@@ -571,7 +571,7 @@ namespace sml
             * all agents have actually terminated their runs.
             *************************************************************/
             bool        IsSoarRunning() ;
-            
+
             /*************************************************************
             * @brief Ask the kernel for the current list of connections
             *        and their status information.
@@ -581,7 +581,7 @@ namespace sml
             *          last time this method was called.
             *************************************************************/
             bool                    GetAllConnectionInfo() ;
-            
+
             /*************************************************************
             * @brief Report number of connections and info about those connections.
             *        These methods report information cached in the last
@@ -594,7 +594,7 @@ namespace sml
             ConnectionInfo const*   GetConnectionInfo(int i) ;
             char const*             GetConnectionStatus(char const* pConnectionName) ;
             char const*             GetAgentStatus(char const* pConnectionName) ;
-            
+
             /*************************************************************
             * @brief Sets the name and current status of this connection.
             *        This information is sent to the kernel and can be requested
@@ -615,7 +615,7 @@ namespace sml
             *  "closing" - client is in the act of shutting down
             *************************************************************/
             bool SetConnectionInfo(char const* pName, char const* pConnectionStatus, char const* pAgentStatus) ;
-            
+
             /*************************************************************
             * @brief   Causes the kernel to issue a SYSTEM_START event.
             *
@@ -627,7 +627,7 @@ namespace sml
             *          but indirectly through a simulation.
             *************************************************************/
             bool FireStartSystemEvent() ;
-            
+
             /*************************************************************
             * @brief   Causes the kernel to issue a SYSTEM_STOP event.
             *
@@ -641,7 +641,7 @@ namespace sml
             *          semantics for "stop-soar".
             *************************************************************/
             bool FireStopSystemEvent() ;
-            
+
             /*************************************************************
             * @brief   Prevents the kernel from sending an smlEVENT_SYSTEM_STOP
             *          event at the of a run.
@@ -656,14 +656,14 @@ namespace sml
             *          request that the kernel fire the event.
             *************************************************************/
             bool SuppressSystemStop(bool state) ;
-            
+
             /*************************************************************
             * @brief Get last command line result
             *
             * @returns True if the last command line call succeeded.
             *************************************************************/
             bool GetLastCommandLineResult();
-            
+
             /*************************************************************
             * @brief If this is an embedded connection using "synchronous execution"
             *        then we need to call this periodically to look for commands
@@ -675,7 +675,7 @@ namespace sml
             *        having to call this).
             *************************************************************/
             bool CheckForIncomingCommands() ;
-            
+
             /*************************************************************
             * @brief See if there are any incoming messages waiting to
             *        be dispatched to event handlers and if so process them.
@@ -691,7 +691,7 @@ namespace sml
             * @return True if processes at least one event
             *************************************************************/
             bool CheckForIncomingEvents() ;
-            
+
             /*************************************************************
             * @brief Start/stop the event thread.
             *
@@ -708,7 +708,7 @@ namespace sml
             *************************************************************/
             bool StartEventThread() ;
             bool StopEventThread() ;
-            
+
             /*************************************************************
             * @brief Register for a "SystemEvent".
             *        Multiple handlers can be registered for the same event.
@@ -732,13 +732,13 @@ namespace sml
             * @returns Unique ID for this callback.  Required when unregistering this callback.
             *************************************************************/
             int RegisterForSystemEvent(smlSystemEventId id, SystemEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             * @returns True if succeeds
             *************************************************************/
             bool    UnregisterForSystemEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief The smlEVENT_INTERRUPT_CHECK event fires every n-th
             *        step (phase) during a run.  The n is controlled by
@@ -755,7 +755,7 @@ namespace sml
             * @param newRate >= 1
             *************************************************************/
             bool SetInterruptCheckRate(int newRate) ;
-            
+
             /*************************************************************
             * @brief Register a handler for a RHS (right hand side) function.
             *        This function can be called in the RHS of a production firing
@@ -781,14 +781,14 @@ namespace sml
             * @returns Unique ID for this callback.  Required when unregistering this callback.
             *************************************************************/
             int AddRhsFunction(char const* pRhsFunctionName, RhsEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular rhs function callback
             *        using the ID passed back from AddRhsFunction().
             * @returns True if succeeds
             *************************************************************/
             bool RemoveRhsFunction(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register a handler for receiving generic messages sent from another client.
             *        The content of the messages are up to the client and really aren't related to Soar, but providing the
@@ -816,14 +816,14 @@ namespace sml
             * @returns Unique ID for this callback.  Required when unregistering this callback.
             *************************************************************/
             int RegisterForClientMessageEvent(char const* pClientName, ClientMessageHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular client message
             *        using the ID passed back from RegisterForClientMessageEvent().
             * @returns True if succeeds
             *************************************************************/
             bool UnregisterForClientMessageEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Send a message to another client (not the Soar kernel).
             *        The other client must have registered for this message to receive it.
@@ -843,7 +843,7 @@ namespace sml
             * @returns The response (if any) from the receiving client.  The string "**NONE**" is reserved to indicate nobody was registered for this event.
             *************************************************************/
             std::string SendClientMessage(Agent* pAgent, char const* pClientName, char const* pMessage) ;
-            
+
             /*************************************************************
             * @brief Register for an "AgentEvent".
             *        Multiple handlers can be registered for the same event.
@@ -865,13 +865,13 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForAgentEvent(smlAgentEventId id, AgentEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             * @returns True if succeeds
             *************************************************************/
             bool    UnregisterForAgentEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for an "UpdateEvent".
             *        Multiple handlers can be registered for the same event.
@@ -886,13 +886,13 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForUpdateEvent(smlUpdateEventId id, UpdateEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             * @returns True if succeeds
             *************************************************************/
             bool    UnregisterForUpdateEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief Register for a string event.
             *        Multiple handlers can be registered for the same event.
@@ -907,13 +907,13 @@ namespace sml
             * @returns A unique ID for this callback (used to unregister the callback later)
             *************************************************************/
             int RegisterForStringEvent(smlStringEventId id, StringEventHandler handler, void* pUserData, bool addToBack = true) ;
-            
+
             /*************************************************************
             * @brief Unregister for a particular event
             * @returns True if succeeds
             *************************************************************/
             bool    UnregisterForStringEvent(int callbackID) ;
-            
+
             /*************************************************************
             * @brief The Soar kernel version is based on sending a request
             *        to the kernel asking for its version and returning the
@@ -931,18 +931,18 @@ namespace sml
             *        E.g. 8.6.1
             *************************************************************/
             std::string GetSoarKernelVersion() ;
-            
+
             /*************************************************************
             * @brief Calls Commit() for all agents -- sending any queued I/O operations
             *        over to the kernel for processing.
             *************************************************************/
             void CommitAll() ;
-            
+
             /*************************************************************
             * @brief Returns true if at least one agent has uncommitted changes.
             *************************************************************/
             bool IsCommitRequired() ;
-            
+
             /*************************************************************
             * @brief Loads an external library (dll/so/dylib) in the local client for the
             * purpose of event or RHS function registration. This can boost performance over
@@ -952,7 +952,7 @@ namespace sml
             * @return error message or empty string for no error
             *************************************************************/
             std::string LoadExternalLibrary(char const* pLibraryCommand);
-            
+
             /*************************************************************
             * @brief Returns the connection information for this kernel
             *        which is how we communicate with the kernel (e.g. embedded,
@@ -966,31 +966,33 @@ namespace sml
             {
                 return m_Connection ;
             }
-            
+
         protected:
             /*************************************************************
             * @brief This function is called when we receive a "call" SML
             *        message from the kernel.
             *************************************************************/
             static soarxml::ElementXML* ReceivedCall(Connection* pConnection, soarxml::ElementXML* pIncoming, void* pUserData) ;
-            
+
             /*************************************************************
             * @brief This function is called (indirectly) when we receive a "call" SML
             *        message from the kernel.
             *************************************************************/
             soarxml::ElementXML* ProcessIncomingSML(Connection* pConnection, soarxml::ElementXML* pIncoming) ;
-            
+
             /*************************************************************
             * @brief The workhorse function to create an embedded connection.
             *        The public methods hide a few of these parameters.
             *************************************************************/
             static Kernel* CreateEmbeddedConnection(bool clientThread, bool optimized, int portToListenOn) ;
-            
+
+#ifndef NO_SVS
             void        SendSVSInput(const char* agentName, const std::string& txt);
             std::string GetSVSOutput(const char* agentName);
             std::string SVSQuery(const char* agentName, const std::string& q);
+#endif
     };
-    
+
 }//closes namespace
 
 #endif //SML_KERNEL_H

--- a/Core/ConnectionSML/src/sml_Names.cpp
+++ b/Core/ConnectionSML/src/sml_Names.cpp
@@ -451,6 +451,8 @@ char const* const sml_Names::kCommand_GetListenerPort       = "get_listener_port
 // command line interface
 char const* const sml_Names::kCommand_CommandLine        = "cmdline" ;
 
+#ifndef NO_SVS
 char const* const sml_Names::kCommand_SVSInput   = "svs_input";
 char const* const sml_Names::kCommand_SVSOutput  = "svs_output";
 char const* const sml_Names::kCommand_SVSQuery  = "svs_query";
+#endif

--- a/Core/ConnectionSML/src/sml_Names.h
+++ b/Core/ConnectionSML/src/sml_Names.h
@@ -29,17 +29,17 @@ namespace sml
             static char const* const kDocType_Notify ;
             static char const* const kSMLVersion ;
             static char const* const kOutputLinkName ;
-            
+
             static const char* const kSoarVersionValue;
             static const char* const kSMLVersionValue;
-            
+
             // <command> tag identifiers
             static char const* const kTagCommand ;
             static char const* const kCommandName ;
             static char const* const kCommandOutput ;
             static char const* const kRawOutput ;
             static char const* const kStructuredOutput ;
-            
+
             // <connection> tag identifiers
             static char const* const kTagConnection ;
             static char const* const kConnectionId ;
@@ -50,34 +50,34 @@ namespace sml
             static char const* const kStatusNotReady ;  // Connection not ready (work needs to be done still)
             static char const* const kStatusReady ;     // Connection ready (registered for events etc.)
             static char const* const kStatusClosing ;   // Connection about to shut down
-            
+
             // <arg> tag identifiers
             static char const* const kTagArg ;
             static char const* const kArgParam ;
             static char const* const kArgType ;
-            
+
             // <error> tag identifiers
             static char const* const kTagError ;
             static char const* const kErrorCode ;
-            
+
             // <name> tag identifiers
             static char const* const kTagName ;
-            
+
             // <result> tag identifiers
             static char const* const kTagResult ;
-            
+
             // input values (for update param)
             static char const* const kValueDelta ;
             static char const* const kValueFull ;
-            
+
             //for RHS output
             static char const* const kTagRHS_write ;
             static char const* const kRHS_String ;
-            
+
             // Tags defined for Trace output at each watch level:
             // <trace> contains the rest.
             static char const* const kTagTrace ;
-            
+
             // <context> tag identifiers for Watch level 1
             static char const* const kTagState ;
             static char const* const kTagOperator ;
@@ -91,7 +91,7 @@ namespace sml
             static char const* const kOperator_Name;
             static char const* const kOperator_DecisionCycleCt;
             static char const* const kOperator_StackLevel ;
-            
+
             // <phase> tag identifiers for Watch level 2
             static char const* const kTagPhase ;
             static char const* const kPhase_Name ;
@@ -110,17 +110,17 @@ namespace sml
             static char const* const kPhaseStatus_End ;
             static char const* const kPhaseFiringType_IE ;
             static char const* const kPhaseFiringType_PE ;
-            
+
             static char const* const kTagSubphase;
             static char const* const kSubphaseName_FiringProductions;
             static char const* const kSubphaseName_ChangingWorkingMemory;
-            
+
             // <prod-firing> tag identifiers for Watch level 3
             static char const* const kTagProduction ;
             static char const* const kProduction_Name ;
             static char const* const kTagProduction_Firing ;
             static char const* const kTagProduction_Retracting ;
-            
+
             // <wme> tag identifiers, also Watch level 4
             static char const* const kTagWME ;
             static char const* const kWME_TimeTag ;
@@ -136,25 +136,25 @@ namespace sml
             static char const* const kValueRemove ;
             static char const* const kTagWMERemove ;
             static char const* const kTagWMEAdd ;
-            
+
             // <preference> tag identifiers, also Watch level 5
             static char const* const kTagPreference ;
             static char const* const kPreference_Type ;
             static char const* const kOSupported ;
             static char const* const kReferent ;
-            
+
             // for warnings controlled by WARNINGS_SYSPARAM
             static char const* const kTagWarning ;
-            
+
             // XML function types for XML output event
             static char const* const kFunctionBeginTag;
             static char const* const kFunctionEndTag;
             static char const* const kFunctionAddAttribute;
-            
+
             // learning stuff
             static char const* const kTagLearning;
             // Tag learning has attribute kTypeString
-            
+
             // filter support
             static char const* const kTagFilter ;
             static char const* const kFilterCommand ;
@@ -162,7 +162,7 @@ namespace sml
             static char const* const kFilterOutput ;
             static char const* const kFilterName ;
             static char const* const kParamNoFiltering ;
-            
+
             //production printing
             static char const* const kTagConditions;
             static char const* const kTagConjunctive_Negation_Condition;
@@ -185,7 +185,7 @@ namespace sml
             static char const* const kAction;
             static char const* const kActionFunction;
             static char const* const kActionId;
-            
+
             //backtrace stuff
             static char const* const kTagBacktrace;
             static char const* const kTagGrounds;
@@ -204,9 +204,9 @@ namespace sml
             static char const* const kBacktracedAlready;
             static char const* const kBacktraceSymbol1;
             static char const* const kBacktraceSymbol2;
-            
+
             static char const* const kTagLocalNegation; // SBW 5/07
-            
+
             // numeric indifference stuff
             static char const* const kTagCandidate;
             static char const* const kCandidateName;
@@ -215,18 +215,18 @@ namespace sml
             static char const* const kCandidateTypeAvg;
             static char const* const kCandidateValue;
             static char const* const kCandidateExpValue;
-            
+
             // output for the verbose command
             static char const* const kTagVerbose;
-            
+
             // support for printing random messages
             static char const* const kTagMessage;
-            
+
             // marker for showing beginning of action-side
             static char const* const kTagActionSideMarker;
-            
+
             // end of tags for Trace output
-            
+
             // Types
             static char const* const kTypeString ;
             static char const* const kTypeInt ;
@@ -235,7 +235,7 @@ namespace sml
             static char const* const kTypeBoolean ;
             static char const* const kTypeID ;
             static char const* const kTypeVariable ;
-            
+
             // Params
             static char const* const kParamAgent ;
             static char const* const kParamKernel ;
@@ -296,12 +296,12 @@ namespace sml
             static char const* const kParamChunkCount;
             static char const* const kParamChunkLongFormat;
             static char const* const kParamPort;
-            
+
             // Parameter names for source command
             static char const* const kParamSourcedProductionCount;
             static char const* const kParamExcisedProductionCount;
             static char const* const kParamIgnoredProductionCount;
-            
+
             // Parameter names for stats command
             static char const* const kParamStatsProductionCountDefault;
             static char const* const kParamStatsProductionCountUser;
@@ -378,7 +378,7 @@ namespace sml
             static char const* const kParamStatsMaxDecisionCycleWMChangesValue;
             static char const* const kParamStatsMaxDecisionCycleFireCountCycle;
             static char const* const kParamStatsMaxDecisionCycleFireCountValue;
-            
+
             // Parameter names for watch command
             static char const* const kParamWatchDecisions;
             static char const* const kParamWatchPhases;
@@ -399,11 +399,11 @@ namespace sml
             static char const* const kParamWatchSMem;
             static char const* const kParamWatchWMA;
             static char const* const kParamWatchGDS;
-            
+
             // Values (these are not case sensitive unlike the rest)
             static char const* const kTrue ;
             static char const* const kFalse ;
-            
+
             // Main command set
             static char const* const kCommand_CreateAgent ;
             static char const* const kCommand_DestroyAgent ;
@@ -437,15 +437,17 @@ namespace sml
             static char const* const kCommand_OutputInit ;
             static char const* const kCommand_ConvertIdentifier ;
             static char const* const kCommand_GetListenerPort ;
-            
+
             // Command line interface
             static char const* const kCommand_CommandLine ;
-            
+
+#ifndef NO_SVS
             static char const* const kCommand_SVSInput ;
             static char const* const kCommand_SVSOutput ;
             static char const* const kCommand_SVSQuery ;
+#endif
     } ;
-    
+
 }
 
 #endif // SML_NAMESH

--- a/Core/KernelSML/src/KernelHeaders.h
+++ b/Core/KernelSML/src/KernelHeaders.h
@@ -30,4 +30,6 @@
 #include "symtab.h"
 #include "io_soar.h"
 #include "wmem.h"
+#ifndef NO_SVS
 #include "svs_interface.h"
+#endif

--- a/Core/KernelSML/src/sml_KernelSML.h
+++ b/Core/KernelSML/src/sml_KernelSML.h
@@ -53,25 +53,25 @@ namespace sml
     class Events ;
     class RunScheduler ;
     class KernelHelpers ;
-    
+
 // Define the CommandFunction which we'll call to process commands
     typedef bool (KernelSML::*CommandFunction)(AgentSML*, char const*, Connection*, AnalyzeXML*, soarxml::ElementXML*);
-    
+
 // Used to store a map from command name to function handler for that command
     typedef std::map< std::string, CommandFunction >    CommandMap ;
     typedef CommandMap::iterator                    CommandMapIter ;
     typedef CommandMap::const_iterator              CommandMapConstIter ;
-    
+
 // Map from agent names to information we keep for SML about those agents.
     typedef std::map< std::string, AgentSML* >  AgentMap ;
     typedef AgentMap::iterator                  AgentMapIter ;
     typedef AgentMap::const_iterator            AgentMapConstIter ;
-    
+
 // Map from kernel agent pointers to information we keep for SML about those agents.
     typedef std::map< agent*, AgentSML* >           KernelAgentMap ;
     typedef KernelAgentMap::iterator                KernelAgentMapIter ;
     typedef KernelAgentMap::const_iterator          KernelAgentMapConstIter ;
-    
+
     class KernelSML
     {
             // Allow the kernel listener to execute command lines directly
@@ -80,83 +80,83 @@ namespace sml
             friend class RunScheduler ;
             friend class AgentSML ;
             friend class Soar_Instance ;
-            
+
         protected:
-        
+
             // On Windows this is set to the DLL's hModule handle.
             static void*        s_hModule ;
-            
+
             // Map from command name to function to handle it
             CommandMap  m_CommandMap ;
-            
+
             // Map from agent names to AgentSML objects, where we keep additional information
             // required for SML about each agent.
             AgentMap        m_AgentMap ;
             KernelAgentMap  m_KernelAgentMap ;
-            
+
             // Command line interface module
             cli::CommandLineInterface m_CommandLineInterface ;
-            
+
             // A listener socket and the list of connections to the kernel
             ConnectionManager* m_pConnectionManager ;
-            
+
             // We'll use a mutex to serialize execution of commands within the kernel.
             // This is really just an insurance policy as I don't think we'll ever execute
             // commands on different threads within kernelSML because we
             // only allow one embedded connection to the kernel, but it's nice to be sure.
             soar_thread::Mutex* m_pKernelMutex ;
-            
+
             // Used to map event IDs to and from strings
             Events*         m_pEventMap ;
-            
+
             // Used to listen for kernel events that are kernel based (not for a specific agent)
             SystemListener  m_SystemListener;
             RhsListener     m_RhsListener;
             AgentListener   m_AgentListener;
             UpdateListener  m_UpdateListener ;
             StringListener  m_StringListener ;
-            
+
             // We can suppress system start and system stop events
             // (allowing us to Run Soar without running a connected simulation).
             bool            m_SuppressSystemStart ;
             bool            m_SuppressSystemStop ;
-            
+
             // When we really issue a stop command we have to be sure we'll send the event
             // so this overrides any suppression setting.  (Use a different flag so it can't
             // be overridden by another call to suppress system stop).
             bool            m_RequireSystemStop ;
-            
+
             RunScheduler*   m_pRunScheduler ;
-            
+
             // If true, whenever a user issues a command that changes the state of the kernel in some manner
             // the command and its results are echoed to anyone listening.  This is useful when two users
             // are debugging the same kernel (and should be off at other times).
             bool            m_EchoCommands ;
-            
+
             int             m_InterruptCheckRate;
             smlPhase        m_StopPoint ;
-            
+
         public:
             void SetStopPoint(bool forever, smlRunStepSize runStepSize, smlPhase m_StopBeforePhase);
             smlPhase GetStopPoint()
             {
                 return m_StopPoint;
             }
-            
+
             int GetInterruptCheckRate()
             {
                 return m_InterruptCheckRate;
             }
-            
+
             /*************************************************************
             * @brief    Creates the singleton kernel object
             *           and starts listening for incoming commands on the
             *           given port.
             *************************************************************/
             static KernelSML* CreateKernelSML(int portToListenOn) ;
-            
+
             int GetListenerPort();
-            
+
             /*************************************************************
             * @brief    Handy utility function for dumping output to the
             *           debugger.
@@ -166,7 +166,7 @@ namespace sml
 #ifdef _DEBUG
                 _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
                 _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
-                
+
                 _CrtDbgReport(_CRT_WARN, pFilename, line, "KernelSML", pMsg);
 #else
                 unused(pFilename) ;
@@ -174,22 +174,22 @@ namespace sml
                 unused(pMsg) ;
 #endif // _DEBUG
             }
-            
+
         public:
             ~KernelSML(void);
-            
+
             /*************************************************************
             * @brief    Shutdown any connections and sockets in preparation
             *           for the kernel process exiting.
             *************************************************************/
             void Shutdown() ;
-            
+
             /*************************************************************
             * @brief    Add a new connection to the list of connections
             *           we're aware of to this soar kernel.
             *************************************************************/
             void AddConnection(Connection* pConnection) ;
-            
+
             /*************************************************************
             * @brief    Add or remove a connection from the list listening
             *           for a particular event in the kernel.
@@ -226,7 +226,7 @@ namespace sml
             {
                 m_StringListener.RemoveListener(eventID, pConnection) ;
             }
-            
+
             /*************************************************************
             * @brief    Notify listeners that this event has occured.
             *************************************************************/
@@ -234,7 +234,7 @@ namespace sml
             {
                 m_UpdateListener.OnKernelEvent(eventID, 0, &runFlags) ;
             }
-            
+
             /*************************************************************
             * @brief    Notify listeners that this event has occured.
             *************************************************************/
@@ -242,7 +242,7 @@ namespace sml
             {
                 m_SystemListener.OnKernelEvent(eventID, 0 , 0) ;
             }
-            
+
             /*************************************************************
             * @brief    Notify listeners that this event has occured.
             *************************************************************/
@@ -250,22 +250,22 @@ namespace sml
             {
                 m_AgentListener.OnEvent(eventID, pAgentSML) ;
             }
-            
+
             /*************************************************************
             * @brief    Notify listeners that this event has occured.
             *************************************************************/
             std::string FireEditProductionEvent(char const* pProduction);
-            
+
             /*************************************************************
             * @brief    Notify listeners that this event has occured.
             *************************************************************/
             std::string FireLoadLibraryEvent(char const* pLibraryCommand);
-            
+
             /*************************************************************
             * @brief  Notify listeners that this event has occured.
             *************************************************************/
             std::string FireCliExtensionMessageEvent(char const* pCliExtCommand);
-            
+
             /*************************************************************
             * @brief    Add or remove a connection from the list implementing
             *           a particular rhs function in the kernel.
@@ -282,38 +282,38 @@ namespace sml
             {
                 return m_RhsListener.ExecuteRhsCommand(pAgentSML, eventID, functionName, arguments, pResult) ;
             }
-            
+
             /*************************************************************
             * @brief    Send this message out to any clients that are listening.
             *           These messages are from one client to another--kernelSML is just
             *           facilitating the message passing process without knowing/caring what is being passed.
             *************************************************************/
             std::string SendClientMessage(AgentSML* pAgentSML, char const* pMessageType, char const* pMessage) ;
-            
+
             /*************************************************************
             * @brief    Send this command line out to all clients that have
             *           registered a filter.  The result is the processed
             *           version of the command line.
             *************************************************************/
             bool SendFilterMessage(AgentSML* pAgent, char const* pCommandLine, std::string* pResult) ;
-            
+
             /*************************************************************
             * @brief    Returns true if at least one filter is registered.
             *************************************************************/
             bool HasFilterRegistered() ;
-            
+
             /*************************************************************
             * @brief Convert from a string version of an event to the int (enum) version.
             *        Returns smlEVENT_INVALID_EVENT (== 0) if the string is not recognized.
             *************************************************************/
             int ConvertStringToEvent(char const* pStr) ;
-            
+
             /*************************************************************
             * @brief Convert from int version of an event to the string form.
             *        Returns NULL if the id is not recognized.
             *************************************************************/
             char const* ConvertEventToString(int id) ;
-            
+
             /*************************************************************
             * @brief Flags used to suppress the firing of system start and
             *        system stop events.
@@ -326,12 +326,12 @@ namespace sml
             {
                 m_SuppressSystemStop = state ;
             }
-            
+
             void RequireSystemStop(bool state)
             {
                 m_RequireSystemStop = state ;
             }
-            
+
             bool IsSystemStartSuppressed()
             {
                 return m_SuppressSystemStart ;
@@ -340,13 +340,13 @@ namespace sml
             {
                 return m_SuppressSystemStop && !m_RequireSystemStop ;
             }
-            
+
             /*************************************************************
             * @brief    Remove any events that this connection was listening to.
             *           Generally do this just prior to deleting the connection.
             *************************************************************/
             void RemoveAllListeners(Connection* pConnection) ;
-            
+
             /*************************************************************
             * @brief    Receive and process any messages from remote connections
             *           that are waiting on a socket.
@@ -354,7 +354,7 @@ namespace sml
             *           for more messages (and presumably shutdown completely).
             *************************************************************/
             bool ReceiveAllMessages() ;
-            
+
             /*************************************************************
             * @brief    Stop the thread that is used to receive messages
             *           from remote connections.  We do this when we're
@@ -363,14 +363,14 @@ namespace sml
             *           of the receiver thread.
             *************************************************************/
             void StopReceiverThread() ;
-            
+
             /*************************************************************
             * @brief Turning this on means we'll start dumping output about messages
             *        being sent and received.  Currently this only applies to remote connections.
             *************************************************************/
             void SetTraceCommunications(bool state) ;
             bool IsTracingCommunications() ;
-            
+
             /*************************************************************
             * @brief    Takes an incoming SML message and responds with
             *           an appropriate response message.
@@ -379,17 +379,17 @@ namespace sml
             * @param pIncoming      The incoming message
             *************************************************************/
             soarxml::ElementXML* ProcessIncomingSML(Connection* pConnection, soarxml::ElementXML* pIncoming) ;
-            
+
             /*************************************************************
             * @brief    Look up an agent from its name.
             *************************************************************/
             AgentSML* GetAgentSML(char const* pAgentName) ;
-            
+
             /*************************************************************
             * @brief    Returns the number of agents.
             *************************************************************/
             int         GetNumberAgents() ;
-            
+
             /*************************************************************
             * @brief    Delete the agent sml object for this agent.
             *           This object stores the data SML uses when working
@@ -397,13 +397,13 @@ namespace sml
             *************************************************************/
             bool DeleteAgentSML(const char* agentName) ;
             //bool DeleteAgentSML(agent* pAgent) ;
-            
+
             /*************************************************************
             * @brief    Stops and deletes all agents.  Generally called
             *           just prior to shutdown.
             *************************************************************/
             void DeleteAllAgents(bool waitTillDeleted) ;
-            
+
             /*************************************************************
             * @brief    The run scheduler is responsible for deciding which
             *           agents to include in a run and actually performing
@@ -413,7 +413,7 @@ namespace sml
             {
                 return m_pRunScheduler ;
             }
-            
+
             /*************************************************************
             * @brief    Defines which phase we stop before when running by decision.
             *           E.g. Pass input phase to stop just after generating output and before receiving input.
@@ -422,7 +422,7 @@ namespace sml
             void SetStopBefore(smlPhase phase) ;
             smlPhase GetStopBefore() ;
             top_level_phase ConvertSMLToSoarPhase(smlPhase phase) ;
-            
+
             /*************************************************************
             * @brief    If true, whenever a user issues a command that changes the state of the kernel in some manner
             *           the command and its results are echoed to anyone listening.  This is useful when two users
@@ -436,53 +436,53 @@ namespace sml
             {
                 return m_EchoCommands ;
             }
-            
+
             /*************************************************************
             * @brief    Request that all agents stop soon
             *************************************************************/
             void InterruptAllAgents(smlStopLocationFlags stopLoc) ;
             void ClearAllInterrupts() ;
-            
+
             // A set of helper functions for tracing kernel wmes
             static void         Symbol2String(Symbol* pSymbol,  bool refCounts, std::ostringstream& buffer);
             static std::string  Wme2String(wme* pWME, bool refCounts);
             static void         PrintDebugWme(char const* pMsg, wme* pWME, bool refCounts = false);
             static void         PrintDebugSymbol(Symbol* pSymbol, bool refCounts = false);
             void                DirectRun(char const* pAgentName, bool forever, int stepSize, int interleaveSizeIn, int count);
-            
+
         protected:
             KernelSML(int portToListenOn);
-            
+
         protected:
             /*************************************************************
             * @brief    Return an object* to the caller.
             *************************************************************/
             bool ReturnResult(Connection* pConnection, soarxml::ElementXML* pResponse, char const* pResult) ;
-            
+
             /*************************************************************
             * @brief    Return an integer result to the caller.
             *************************************************************/
             bool ReturnIntResult(Connection* pConnection, soarxml::ElementXML* pResponse, int64_t result) ;
-            
+
             /*************************************************************
             * @brief    Return a boolean result to the caller.
             *************************************************************/
             bool ReturnBoolResult(Connection* pConnection, soarxml::ElementXML* pResponse, bool result) ;
-            
+
             /*************************************************************
             * @brief    Return an invalid argument error to the caller.
             *************************************************************/
             bool InvalidArg(Connection* pConnection, soarxml::ElementXML* pResponse, char const* pCommandName, char const* pErrorDescription) ;
-            
+
             void BuildCommandMap() ;
-            
+
             bool ProcessCommand(char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             // There should always be exactly one local connection to the kernel (the process that loaded us).
             Connection* GetEmbeddedConnection() ;
-            
+
             // Our command handlers
-            
+
             /*************************************************************
             * @brief    A command handler (SML message->appropriate gSKI handling).
             *
@@ -520,17 +520,18 @@ namespace sml
             bool HandleGetInitialTimeTag(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             bool HandleConvertIdentifier(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             bool HandleGetListenerPort(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             // Note: Register and unregister are both sent to this one handler
             bool HandleRegisterForEvent(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
+#ifndef NO_SVS
             bool HandleSVSInput(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+
             bool HandleSVSOutput(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
             bool HandleSVSQuery(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse) ;
-            
+#endif
     };
-    
+
 }
 
 #endif // SML_KERNEL_H

--- a/Core/KernelSML/src/sml_KernelSMLHandlers.cpp
+++ b/Core/KernelSML/src/sml_KernelSMLHandlers.cpp
@@ -74,9 +74,11 @@ void KernelSML::BuildCommandMap()
     m_CommandMap[sml_Names::kCommand_GetInitialTimeTag] = &sml::KernelSML::HandleGetInitialTimeTag ;
     m_CommandMap[sml_Names::kCommand_ConvertIdentifier] = &sml::KernelSML::HandleConvertIdentifier;
     m_CommandMap[sml_Names::kCommand_GetListenerPort]   = &sml::KernelSML::HandleGetListenerPort;
+#ifndef NO_SVS
     m_CommandMap[sml_Names::kCommand_SVSInput] = &sml::KernelSML::HandleSVSInput;
     m_CommandMap[sml_Names::kCommand_SVSOutput] = &sml::KernelSML::HandleSVSOutput;
     m_CommandMap[sml_Names::kCommand_SVSQuery] = &sml::KernelSML::HandleSVSQuery;
+#endif
 }
 
 /*************************************************************
@@ -1045,6 +1047,7 @@ bool KernelSML::HandleGetListenerPort(AgentSML* /*pAgentSML*/, char const* /*pCo
     return this->ReturnIntResult(pConnection, pResponse, this->GetListenerPort());
 }
 
+#ifndef NO_SVS
 bool KernelSML::HandleSVSInput(AgentSML* pAgentSML, char const* pCommandName, Connection* pConnection, AnalyzeXML* pIncoming, soarxml::ElementXML* pResponse)
 {
     if (pAgentSML->GetSoarAgent()->svs->is_enabled())
@@ -1082,3 +1085,4 @@ bool KernelSML::HandleSVSQuery(AgentSML* pAgentSML, char const* pCommandName, Co
     std::string res = pAgentSML->GetSoarAgent()->svs->svs_query(pLine);
     return this->ReturnResult(pConnection, pResponse, res.c_str());
 }
+#endif

--- a/Core/SConscript
+++ b/Core/SConscript
@@ -57,8 +57,10 @@ srcs = [
 if compiler == 'msvc':
     srcs.append(('pcre/pcre.cxx', Glob('pcre/*.c')))
 
-svs_objs, svs_inc = SConscript('SVS/SConscript')
-kernel_env.Prepend(CPPPATH = svs_inc)
+svs_objs = []
+if not GetOption('nosvs'):
+    svs_objs, svs_inc = SConscript('SVS/SConscript')
+    kernel_env.Prepend(CPPPATH = svs_inc)
 
 if GetOption('static'):
     soarlib = kernel_env.Library('Soar', [s[scu] for s in srcs] + svs_objs)

--- a/Core/SoarKernel/src/agent.cpp
+++ b/Core/SoarKernel/src/agent.cpp
@@ -56,7 +56,9 @@
 #include "soar_instance.h"
 #include "variablization_manager.h"
 #include "output_manager.h"
+#ifndef NO_SVS
 #include "svs_interface.h"
+#endif
 
 /* ===================================================================
 
@@ -137,7 +139,9 @@ void init_soar_agent(agent* thisAgent)
 
     reset_statistics(thisAgent);
 
+#ifndef NO_SVS
     thisAgent->svs = make_svs(thisAgent);
+#endif
 
     /* RDF: For gSKI */
     init_agent_memory(thisAgent);
@@ -486,7 +490,9 @@ void destroy_soar_agent(agent* delete_agent)
 
     delete delete_agent->smem_db;
 
+#ifndef NO_SVS
     delete delete_agent->svs;
+#endif
 
     // cleanup statistics db
     stats_close(delete_agent);

--- a/Core/SoarKernel/src/agent.h
+++ b/Core/SoarKernel/src/agent.h
@@ -100,7 +100,9 @@ typedef struct alpha_mem_struct alpha_mem;
 typedef struct token_struct token;
 
 class stats_statement_container;
+#ifndef NO_SVS
 class svs_interface;
+#endif
 
 typedef struct agent_struct
 {
@@ -948,7 +950,9 @@ typedef struct agent_struct
         std::map<std::vector<std::string>, Entry> split;
     };
     std::map<goal_stack_level, RL_Trace> rl_trace;
+#ifndef NO_SVS
     svs_interface* svs;
+#endif
 } agent;
 /*************** end of agent struct *****/
 

--- a/Core/SoarKernel/src/decide.cpp
+++ b/Core/SoarKernel/src/decide.cpp
@@ -48,7 +48,9 @@
 
 #include "episodic_memory.h"
 #include "semantic_memory.h"
+#ifndef NO_SVS
 #include "svs_interface.h"
+#endif
 #include "test.h"
 #include "debug.h"
 
@@ -2883,8 +2885,9 @@ void remove_existing_context_and_descendents(agent* thisAgent, Symbol* goal)
     symbol_remove_ref(thisAgent, goal->id->smem_header);
     free_with_pool(&(thisAgent->smem_info_pool), goal->id->smem_info);
 
+#ifndef NO_SVS
     thisAgent->svs->state_deletion_callback(goal);
-
+#endif
     /* REW: BUG
      * Tentative assertions can exist for removed goals.  However, it looks
      * like the removal forces a tentative retraction, which then leads to
@@ -3015,7 +3018,9 @@ void create_new_context(agent* thisAgent, Symbol* attr_of_impasse, byte impasse_
                           CREATE_NEW_CONTEXT_CALLBACK,
                           static_cast<soar_call_data>(id));
 
+#ifndef NO_SVS
     thisAgent->svs->state_creation_callback(id);
+#endif
 }
 
 /* ------------------------------------------------------------------

--- a/Core/SoarKernel/src/init_soar.cpp
+++ b/Core/SoarKernel/src/init_soar.cpp
@@ -44,7 +44,9 @@
 #include "episodic_memory.h"
 #include "semantic_memory.h"
 #include "variablization_manager.h"
+#ifndef NO_SVS
 #include "svs_interface.h"
+#endif
 #include "output_manager.h"
 
 /* REW: begin 08.20.97   these defined in consistency.c  */
@@ -626,10 +628,12 @@ void do_one_top_level_phase(agent* thisAgent)
                                       BEFORE_INPUT_PHASE_CALLBACK,
                                       reinterpret_cast<soar_call_data>(INPUT_PHASE));
 
+#ifndef NO_SVS
                 if (thisAgent->svs->is_enabled())
                 {
                     thisAgent->svs->input_callback();
                 }
+#endif
                 do_input_cycle(thisAgent);
 
                 thisAgent->run_phase_count++ ;
@@ -990,10 +994,12 @@ void do_one_top_level_phase(agent* thisAgent)
                                   BEFORE_OUTPUT_PHASE_CALLBACK,
                                   reinterpret_cast<soar_call_data>(OUTPUT_PHASE));
 
+#ifndef NO_SVS
             if (thisAgent->svs->is_enabled())
             {
                 thisAgent->svs->output_callback();
             }
+#endif
             /** KJC June 05:  moved output function timers into do_output_cycle ***/
 
             do_output_cycle(thisAgent);

--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,7 @@ print "   kernel cli sml_java debugger headers"
 print "Settings available:"
 print "   --opt, --static, --out, --build, --no-scu, --verbose"
 print "   --cc, --cxx, --cflags, --lnflags, --no-default-flags"
+print "   --no-svs"
 print "================================================================================"
 
 def execute(cmd):
@@ -144,6 +145,8 @@ AddOption('--opt', action='store_true', dest='opt', default=False, help='Enable 
 
 AddOption('--verbose', action='store_true', dest='verbose', default=False, help='Output full compiler commands')
 
+AddOption('--no-svs', action='store_true', dest='nosvs', default=False, help='Build Soar without SVS functionality')
+
 msvc_version = "12.0"
 cl_target_architecture = ''
 if sys.platform == 'win32':
@@ -188,6 +191,8 @@ lnflags = []
 libs = ['Soar']
 if compiler == 'g++':
     libs += [ 'pthread', 'dl', 'm' ]
+    if GetOption('nosvs'):
+        cflags.append('-DNO_SVS')
     if GetOption('defflags'):
         cflags.append('-Wreturn-type')
 
@@ -222,7 +227,8 @@ if compiler == 'g++':
 
 elif compiler == 'msvc':
     cflags = ['/EHsc', '/D', '_CRT_SECURE_NO_DEPRECATE', '/D', '_WIN32', '/W2', '/bigobj']
-
+    if GetOption('nosvs'):
+        cflags.extend(' /D NO_SVS'.split())
     if GetOption('defflags'):
         if GetOption('opt'):
             cflags.extend(' /MD /O2 /D NDEBUG'.split())

--- a/Tests/UnitTests/src/cliparsertest.h
+++ b/Tests/UnitTests/src/cliparsertest.h
@@ -8,7 +8,7 @@ class CliAdapter : public cli::Cli
 {
     public:
         virtual ~CliAdapter() {}
-        
+
         virtual bool SetError(const std::string& error)
         {
             return false;
@@ -321,23 +321,25 @@ class CliAdapter : public cli::Cli
         {
             return false;
         }
+#ifndef NO_SVS
         virtual bool DoSVS(const std::vector<std::string>& args)
         {
             return false;
         }
+#endif
 };
 
 class CliEcho : public CliAdapter
 {
     public:
         virtual ~CliEcho() {}
-        
+
         void SetExpected(unsigned numArgs, bool newLine)
         {
             this->numArgs = numArgs;
             this->newLine = newLine;
         }
-        
+
         virtual bool DoEcho(const std::vector<std::string>& argv, bool echoNewline)
         {
             return (argv.size() == numArgs) && (echoNewline == newLine);
@@ -351,12 +353,12 @@ class CliMaxDCTime : public CliAdapter
 {
     public:
         virtual ~CliMaxDCTime() {}
-        
+
         void SetExpected(int n)
         {
             this->n = n;
         }
-        
+
         virtual bool DoMaxDCTime(const int n)
         {
             return this->n == n;

--- a/Tests/UnitTests/src/epmemtest.cpp
+++ b/Tests/UnitTests/src/epmemtest.cpp
@@ -16,8 +16,10 @@ class EpmemTest : public CPPUNIT_NS::TestCase
 #ifdef DO_EPMEM_TESTS
         CPPUNIT_TEST(testEpmemUnit);
         CPPUNIT_TEST(testHamiltonian);
+#ifndef NO_SVS
         CPPUNIT_TEST(testSVS);
         CPPUNIT_TEST(testSVSHard);
+#endif
 #endif
         CPPUNIT_TEST_SUITE_END();
 
@@ -31,8 +33,10 @@ class EpmemTest : public CPPUNIT_NS::TestCase
 
         void testEpmemUnit();
         void testHamiltonian();
+#ifndef NO_SVS
         void testSVS();
         void testSVSHard();
+#endif
 
         sml::Kernel* pKernel;
         sml::Agent* pAgent;
@@ -84,6 +88,7 @@ void EpmemTest::testHamiltonian()
     CPPUNIT_ASSERT(succeeded);
 }
 
+#ifndef NO_SVS
 void EpmemTest::testSVS()
 {
     source("svs.soar");
@@ -97,3 +102,4 @@ void EpmemTest::testSVSHard()
     pAgent->RunSelf(3, sml::sml_DECISION);
     CPPUNIT_ASSERT(succeeded);
 }
+#endif

--- a/Tests/UnitTests/src/fulltests.cpp
+++ b/Tests/UnitTests/src/fulltests.cpp
@@ -63,7 +63,9 @@ class FullTests : public CPPUNIT_NS::TestCase
         CPPUNIT_TEST(testConvertIdentifier);
         CPPUNIT_TEST(testOutputLinkRemovalOrdering);
         CPPUNIT_TEST(testNegatedConjunctiveTestReorder);
+#ifndef NO_SVS
         CPPUNIT_TEST(testSVS);
+#endif
         CPPUNIT_TEST(testPreferenceSemantics);                  // bug 234
         CPPUNIT_TEST(testNegatedConjunctiveChunkLoopBug510);    // bug 510
         CPPUNIT_TEST(testNegatedConjunctiveTestUnbound);        // bug 517
@@ -118,7 +120,9 @@ class FullTests : public CPPUNIT_NS::TestCase
         TEST_DECLARATION(testGDSBug1144);
         TEST_DECLARATION(testGDSBug1011);
         TEST_DECLARATION(testLearn);
+#ifndef NO_SVS
         TEST_DECLARATION(testSVS);
+#endif
         TEST_DECLARATION(testPreferenceSemantics);
         TEST_DECLARATION(testMatchTimeInterrupt);
         TEST_DECLARATION(testNegatedConjunctiveTestReorder);
@@ -1639,12 +1643,14 @@ TEST_DEFINITION(testLearn)
     }
 }
 
+#ifndef NO_SVS
 TEST_DEFINITION(testSVS)
 {
     m_pKernel->AddRhsFunction("test-failure", Handlers::MyRhsFunctionFailureHandler, 0) ;
     loadProductions("test_agents/testSVS.soar");
     m_pAgent->ExecuteCommandLine("run");
 }
+#endif
 
 TEST_DEFINITION(testPreferenceSemantics)
 {


### PR DESCRIPTION
Add a macro, `NO_SVS` which, if defined, prevents any reference to SVS from being used in the core code. Add a `--no-svs` option to Sconscript that defines the macro and prevents running the Sconscript in the SVS folder.