### PR TITLE
use more common syntax for variadic templates

### DIFF
--- a/Core/SoarKernel/src/debug.h
+++ b/Core/SoarKernel/src/debug.h
@@ -44,15 +44,15 @@
 
     //extern sqlite_database  *db_err_epmem_db, *db_err_smem_db;
 
-    #define dprint(mode, format, args...) Output_Manager::Get_OM().debug_print_sf (mode, format , ##args)
-    #define dprint_set_indents(mode, args...) Output_Manager::Get_OM().set_dprint_indents (mode , ##args)
-    #define dprint_set_test_format(mode, args...) Output_Manager::Get_OM().set_dprint_test_format (mode , ##args)
-    #define dprint_clear_indents(mode, args...) Output_Manager::Get_OM().clear_dprint_indents (mode , ##args)
-    #define dprint_clear_test_format(mode, args...) Output_Manager::Get_OM().clear_dprint_test_format (mode , ##args)
-    #define dprint_y(mode, format, ...) Output_Manager::Get_OM().debug_print_sf (mode, format , ##args)
-    #define dprint_noprefix(mode, args...) Output_Manager::Get_OM().debug_print_sf_noprefix (mode , ##args)
+    #define dprint(mode, format, ...) Output_Manager::Get_OM().debug_print_sf (mode, format , __VA_ARGS__)
+    #define dprint_set_indents(mode, ...) Output_Manager::Get_OM().set_dprint_indents (mode , __VA_ARGS__)
+    #define dprint_set_test_format(mode, ...) Output_Manager::Get_OM().set_dprint_test_format (mode , __VA_ARGS__)
+    #define dprint_clear_indents(mode, ...) Output_Manager::Get_OM().clear_dprint_indents (mode , __VA_ARGS__)
+    #define dprint_clear_test_format(mode, ...) Output_Manager::Get_OM().clear_dprint_test_format (mode , __VA_ARGS__)
+    #define dprint_y(mode, format, ...) Output_Manager::Get_OM().debug_print_sf (mode, format , __VA_ARGS__)
+    #define dprint_noprefix(mode, ...) Output_Manager::Get_OM().debug_print_sf_noprefix (mode , __VA_ARGS__)
     #define dprint_start_fresh_line(mode) Output_Manager::Get_OM().debug_start_fresh_line (mode)
-    #define dprint_header(mode, h, args...) Output_Manager::Get_OM().debug_print_header (mode , h , ##args)
+    #define dprint_header(mode, h, ...) Output_Manager::Get_OM().debug_print_header (mode , h , __VA_ARGS__)
 
     /* -- The rest of these should all be migrated to soar format strings -- */
     #define dprint_current_lexeme(mode) Output_Manager::Get_OM().print_current_lexeme (mode)
@@ -63,15 +63,15 @@
     #define dprint_varnames(mode, var_names) Output_Manager::Get_OM().print_varnames (mode, var_names)
     #define dprint_all_inst(mode) Output_Manager::Get_OM().print_all_inst (mode)
 #else
-    #define dprint(mode, format, args...) ((void)0)
-    #define dprint_set_indents(mode, args...) ((void)0)
-    #define dprint_set_test_format(mode, args...) ((void)0)
-    #define dprint_clear_indents(mode, args...) ((void)0)
-    #define dprint_clear_test_format(mode, args...) ((void)0)
+    #define dprint(mode, format, ...) ((void)0)
+    #define dprint_set_indents(mode, ...) ((void)0)
+    #define dprint_set_test_format(mode, ...) ((void)0)
+    #define dprint_clear_indents(mode, ...) ((void)0)
+    #define dprint_clear_test_format(mode, ...) ((void)0)
     #define dprint_y(mode, format, ...) ((void)0)
     #define dprint_noprefix(mode, format, ...) ((void)0)
     #define dprint_start_fresh_line(mode) ((void)0)
-    #define dprint_header(mode, h, args...) ((void)0)
+    #define dprint_header(mode, h, ...) ((void)0)
 
     #define dprint_current_lexeme(mode) ((void)0)
     #define dprint_production(mode, prod) ((void)0)

--- a/Core/SoarKernel/src/debug_print_speed_test.cpp
+++ b/Core/SoarKernel/src/debug_print_speed_test.cpp
@@ -6,20 +6,20 @@
 
 static Output_Manager* thisOutput_Manager = NULL;
 
-//#define test_print_function(format, args...) dprint (DT_DEBUG, format , ##args)
-//#define test_print_function(format, args...) Output_Manager::Get_OM().debug_print_sf (DT_DEBUG, format , ##args)
-//#define test_print_function(format, args...) Output_Manager::Get_OM().debug_print_sf_noprefix (DT_DEBUG, format , ##args)
-//#define test_print_function(format, args...) Output_Manager::Get_OM().print_sf (format , ##args)
+//#define test_print_function(format, ...) dprint (DT_DEBUG, format , __VA_ARGS__)
+//#define test_print_function(format, ...) Output_Manager::Get_OM().debug_print_sf (DT_DEBUG, format , __VA_ARGS__)
+//#define test_print_function(format, ...) Output_Manager::Get_OM().debug_print_sf_noprefix (DT_DEBUG, format , __VA_ARGS__)
+//#define test_print_function(format, ...) Output_Manager::Get_OM().print_sf (format , __VA_ARGS__)
 
-//#define test_print_function(format, args...) print (debug_agent, format , ##args)
-//#define test_print_function(format, args...) print_with_symbols (debug_agent, format , ##args)
-#define test_print_function(format, args...) print_old (debug_agent, format , ##args)
+//#define test_print_function(format, ...) print (debug_agent, format , __VA_ARGS__)
+//#define test_print_function(format, ...) print_with_symbols (debug_agent, format , __VA_ARGS__)
+#define test_print_function(format, ...) print_old (debug_agent, format , __VA_ARGS__)
 
-//#define test_print_function(format, args...) Output_Manager::Get_OM().printa_sf(debug_agent, format , ##args)
-//#define test_print_function(format, args...) thisOutput_Manager->printa_sf(debug_agent, format , ##args)
+//#define test_print_function(format, ...) Output_Manager::Get_OM().printa_sf(debug_agent, format , __VA_ARGS__)
+//#define test_print_function(format, ...) thisOutput_Manager->printa_sf(debug_agent, format , __VA_ARGS__)
 
-//#define test_print_function(format, args...) dprint_y (DT_DEBUG, format , ##args)
-//#define test_print_function(format, args...) dprint_macro (DT_DEBUG, format , ##args)
+//#define test_print_function(format, ...) dprint_y (DT_DEBUG, format , __VA_ARGS__)
+//#define test_print_function(format, ...) dprint_macro (DT_DEBUG, format , __VA_ARGS__)
 
 void test_print_speed()
 {


### PR DESCRIPTION
Named variadic templates (`args...`) are apparently a GNU extension,
and may cause trouble elsewhere (like my MSVC compiler). Change them
out for the standard non-named syntax that uses `__VA_ARGS__` to refer
to the variadic argument.