### PR TITLE
fix all possible warnings

### DIFF
--- a/Core/ClientSMLSWIG/Tcl/SConscript
+++ b/Core/ClientSMLSWIG/Tcl/SConscript
@@ -116,6 +116,10 @@ elif sys.platform == 'linux2':
 else:
   clone.Append(LIBS=[tcl_lib])
 
+# Prevent "Command line warning D9025 : overriding '/W2' with '/w'"
+if '/W2' in clone['CPPFLAGS']:
+  clone['CPPFLAGS'].remove('/W2')
+
 # Create the SWIG dll for tcl
 tclstep2 = clone.SharedLibrary(libname, swig_tcl_wrapper_cpp)
 lib = clone.Install(lib_install_dir, tclstep2)

--- a/Core/ClientSMLSWIG/sml_ClientInterface.i
+++ b/Core/ClientSMLSWIG/sml_ClientInterface.i
@@ -116,6 +116,8 @@
 #include "sml_ClientAnalyzedXML.h"
 #include "soar_instance.h"
 %}
+// name this () operator from soar_instance.h so it can be wrapped
+%rename(compare) cmp_str::operator();
 
 //
 // Override EXPORT macro
@@ -152,13 +154,13 @@
 #include <stdlib.h>
 #include <crtdbg.h>
 
-bool __stdcall DllMain( void * hModule, 
-                       unsigned long  ul_reason_for_call, 
+bool __stdcall DllMain( void * hModule,
+                       unsigned long  ul_reason_for_call,
                        void * lpReserved
 					 )
 {
 	//_crtBreakAlloc = 13542;
-	_CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF ); 
+	_CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF );
 	unused(hModule) ;
 	unused(ul_reason_for_call) ;
 	unused(lpReserved) ;

--- a/Core/SoarKernel/src/episodic_memory.h
+++ b/Core/SoarKernel/src/episodic_memory.h
@@ -678,4 +678,11 @@ struct epmem_interval_comparator
 };
 typedef std::priority_queue<epmem_interval*, std::vector<epmem_interval*>, epmem_interval_comparator> epmem_interval_pq;
 
+// suppress long "decorated name length exceeded" warning;
+// applies for the rest of the TU, which is where templates are expanded
+// and the warning is generated.
+#ifdef _MSC_VER
+  #pragma warning(disable : 4503)
 #endif
+
+#endif // EPISODIC_MEMORY_H

--- a/Core/SoarKernel/src/explain.cpp
+++ b/Core/SoarKernel/src/explain.cpp
@@ -503,7 +503,7 @@ void explain_trace(agent* thisAgent, const char* chunk_name, backtrace_str* prod
         }
     }
 
-    if (prod->result == true)
+    if (prod->result == 1)
     {
         print(thisAgent,  "A result to be generated.\n");
     }

--- a/Core/SoarKernel/src/semantic_memory.cpp
+++ b/Core/SoarKernel/src/semantic_memory.cpp
@@ -4252,8 +4252,8 @@ bool smem_parse_remove(agent* thisAgent, const char* chunks_str, std::string** e
                     if ((*triple_ptr_iter)->value->symbol_type == IDENTIFIER_SYMBOL_TYPE)
                     {
                         //If the chunk was retrieved and it is an identifier it is lti.
-                        smem_chunk_value_lti temp_lti;
-                        smem_chunk_value_constant temp_const;
+                        smem_chunk_value_lti temp_lti = {};
+                        smem_chunk_value_constant temp_const = {};
                         temp_val->val_const = temp_const;
                         temp_val->val_const.val_type = value_lti_t;
                         temp_val->val_lti = temp_lti;
@@ -4267,8 +4267,8 @@ bool smem_parse_remove(agent* thisAgent, const char* chunks_str, std::string** e
                     }
                     else //If the value is not an identifier, then it is a "constant".
                     {
-                        smem_chunk_value_constant temp_const;
-                        smem_chunk_value_lti temp_lti;
+                        smem_chunk_value_constant temp_const = {};
+                        smem_chunk_value_lti temp_lti = {};
                         temp_val->val_lti = temp_lti;
                         temp_val->val_lti.val_type = value_const_t;
                         temp_val->val_const.val_type = value_const_t;
@@ -4283,8 +4283,8 @@ bool smem_parse_remove(agent* thisAgent, const char* chunks_str, std::string** e
                     if ((*triple_ptr_iter)->value->symbol_type == IDENTIFIER_SYMBOL_TYPE)
                     {
                         //If the chunk was retrieved and it is an identifier it is lti.
-                        smem_chunk_value_lti temp_lti;
-                        smem_chunk_value_constant temp_const;
+                        smem_chunk_value_lti temp_lti = {};
+                        smem_chunk_value_constant temp_const = {};
                         temp_val->val_const = temp_const;
                         temp_val->val_const.val_type = value_lti_t;
                         temp_val->val_lti = temp_lti;
@@ -4298,8 +4298,8 @@ bool smem_parse_remove(agent* thisAgent, const char* chunks_str, std::string** e
                     }
                     else //If the value is nt an identifier, then it is a "constant".
                     {
-                        smem_chunk_value_constant temp_const;
-                        smem_chunk_value_lti temp_lti;
+                        smem_chunk_value_constant temp_const = {};
+                        smem_chunk_value_lti temp_lti = {};
                         temp_val->val_lti = temp_lti;
                         temp_val->val_lti.val_type = value_const_t;
                         temp_val->val_const.val_type = value_const_t;


### PR DESCRIPTION
Fix all of the fixable warnings generated during a build:

`Command line warning D9025 : overriding '/W2' with '/w'`
was caused by trying to suppress warnings when building SWIG/TCL after
having set /W2 at the top level.

`decorated name length exceeded, name was truncated...` warnings were
caused by complicated structures in episodic_memory.h, and the warning
has to be suppressed at the end of the file since the warning is about
templates and they are expanded after the rest of the file is
processed.

Swig emitted `Warning 503: Can't wrap 'operator ()' unless renamed to
a valid identifier.` because of the `()` overload done in the
`cmp_str` struct in soar_instance.h, and was solved by instructing
Swig to rename it to `compare`.

Line 506 of explain.cpp was combaring a boolean with with a
`backtrace_str.result`, which is an int which if set to 1 indicates
that the structure instance is the result of a chunk. It might be
better to change the structure to hold a boolean instead of an int.

Warnings were emitted in semantic_memory.cpp because `temp_lti` and
`temp_const` were not initialized (in multiple places).

I did not touch the warning emitted by Export.h as it seems to be
purposeful; the warning is emitted when a non-static library is built.
