### PR TITLE
quick fix for #245

### DIFF
--- a/Core/shared/tokenizer.h
+++ b/Core/shared/tokenizer.h
@@ -39,7 +39,7 @@ namespace soar
     {
         public:
             virtual ~tokenizer_callback() {}
-            
+
             /**
              * Implement to handle commands. The words of the command are in the
              * passed argv vector. The first entry in the vector is the command.
@@ -51,7 +51,7 @@ namespace soar
              */
             virtual bool handle_command(std::vector<std::string>& argv) = 0;
     };
-    
+
     /**
      * A smart index in to the tokenizer input buffer. Encapsulates a lot of
      * code necessary for figuring out where errors happen.
@@ -62,7 +62,7 @@ namespace soar
             int line;
             int offset;
             const char* current;
-            
+
         public:
             /**
              * Create with null input buffer, call set_current before using.
@@ -71,7 +71,7 @@ namespace soar
             {
                 set_current(0);
             }
-            
+
             /**
              * Create with input buffer, equivalient to using default constructor
              * and calling set_current.
@@ -81,9 +81,9 @@ namespace soar
             {
                 set_current(initial);
             }
-            
+
             virtual ~tokenizer_current() {}
-            
+
             /**
              * Set the input buffer, point to the first character in the buffer.
              * Resets line and offset counters.
@@ -103,7 +103,7 @@ namespace soar
                     offset = 0;
                 }
             }
-            
+
             /**
              * Invalidate the current pointer. Used to indicate error state.
              */
@@ -111,7 +111,7 @@ namespace soar
             {
                 current = 0;
             }
-            
+
             /**
              * Increment the current pointer to the next char in the buffer.  Keeps
              * track of offset in to buffer and newline count as they occur.
@@ -126,7 +126,7 @@ namespace soar
                 current += 1;
                 offset += 1;
             }
-            
+
             /**
              * Returns the current line number.
              * @return The current line number.
@@ -135,7 +135,7 @@ namespace soar
             {
                 return line;
             }
-            
+
             /**
              * Returns how many characters of the current line have been read.
              * @return The current offset.
@@ -144,7 +144,7 @@ namespace soar
             {
                 return offset;
             }
-            
+
             /**
              * Returns true if not in an error state.
              * @return true if not in an error state.
@@ -153,7 +153,7 @@ namespace soar
             {
                 return current != 0;
             }
-            
+
             /**
              * Returns true if in an error state.
              * @return true if in an error state.
@@ -162,7 +162,7 @@ namespace soar
             {
                 return !current;
             }
-            
+
             /**
              * Dereference the pointer and retrieve the current character.
              * This will segfault if this->bad() is true.
@@ -172,7 +172,7 @@ namespace soar
             {
                 return *current;
             }
-            
+
             /**
              * Check to see if the current character is the end of input.
              * @return true if at end of input.
@@ -182,7 +182,7 @@ namespace soar
                 return !*current;
             }
     };
-    
+
     /**
      * Essentially implements a simple Tcl parser, with some exceptions.
      *
@@ -307,13 +307,13 @@ namespace soar
             int command_start_line;         ///< The line that the first word is on.
             const char* error;              ///< Error message.
             std::string last_arg;           ///< Last valid command processed
-            
+
         public:
             tokenizer()
                 : callback(0), error(0)
             {}
             virtual ~tokenizer() {}
-            
+
             /**
              * Set the current callback handler. There can only be one at a time.
              * To unset, call this with null.
@@ -323,7 +323,7 @@ namespace soar
             {
                 this->callback = callback;
             }
-            
+
             /**
              * Evaluate some input, return true if there were no errors, and issue
              * callbacks at command separators (if a callback is registered).
@@ -334,7 +334,7 @@ namespace soar
                 current.set_current(input);
                 command_start_line = 1;
                 error = 0;
-                
+
                 while (current.good())
                 {
                     if (current.eof())
@@ -345,7 +345,7 @@ namespace soar
                 }
                 return current.good();
             }
-            
+
             /**
              * Returns the line number that the command started on.
              * @return The line number that the command started on.
@@ -354,7 +354,7 @@ namespace soar
             {
                 return command_start_line;
             }
-            
+
             /**
              * Returns the current line number, useful when there was a parse
              * error.
@@ -364,7 +364,7 @@ namespace soar
             {
                 return current.get_line();
             }
-            
+
             /**
              * Returns an error string if there was a parse error, or null if the
              * error came from a callback.
@@ -374,7 +374,7 @@ namespace soar
             {
                 return error;
             }
-            
+
             /**
              * Returns how many characters of the current line have been read.
              * @return The current offset.
@@ -383,7 +383,7 @@ namespace soar
             {
                 return current.get_offset();
             }
-            
+
         private:
             /**
              * Parses a command, at least one word. Calls the callback handler.
@@ -396,17 +396,17 @@ namespace soar
                 {
                     skip_whitespace();
                 }
-                
+
                 if (current.bad())
                 {
                     return;
                 }
-                
+
                 if (argv.empty())
                 {
                     return;
                 }
-                
+
 #ifdef PRINT_CALLBACKS
                 std::cout << "\n[";
                 for (int i = 0; i < argv.size(); i++)
@@ -433,7 +433,7 @@ namespace soar
                     }
                 }
             }
-            
+
             /**
              * Parse the next word, return false when a command separator is
              * encountered.
@@ -445,41 +445,49 @@ namespace soar
                 {
                     return false;
                 }
-                
+
                 std::string word;
                 if (argv.empty())
                 {
                     command_start_line = current.get_line();
                 }
-                
+
                 switch (current.get())
                 {
                     case ';':
                         break;
-                        
+
                     case '#':
                         skip_to_end_of_line();
                         break;
-                        
+
                     case '"':
                         argv.push_back(word);
-                        read_quoted_string(argv);
+                        read_quoted_string(argv, '"');
                         break;
-                        
+
+                    case '|':
+                        argv.push_back(word);
+                        // pipes need to be saved for proper parsing later
+                        argv.back().push_back('|');
+                        read_quoted_string(argv, '|');
+                        argv.back().push_back('|');
+                        break;
+
                     case '{':
                         argv.push_back(word);
                         read_braces(argv);
                         break;
-                        
+
                     default:
                         argv.push_back(word);
                         read_normal_word(argv);
                         break;
                 }
-                
+
                 return !at_end_of_command();
             }
-            
+
             /**
              * Store a word that doesn't start with { or " in to argv.back().
              */
@@ -497,24 +505,24 @@ namespace soar
                                 return;
                             }
                             break;
-                            
+
                         case ';':
                             return;
-                            
+
                         case '#':
                             skip_to_end_of_line();
                             return;
-                            
+
                         default:
                             current.increment();
                             break;
                     }
-                    
+
                     argv.back().push_back(c);
                 }
                 while (!current.eof() && !isspace(current.get()));
             }
-            
+
             /**
              * @return true if at command separator.
              */
@@ -529,29 +537,29 @@ namespace soar
                             current.increment();
                         case 0:
                             return true;
-                            
+
                         default:
                             break;
                     }
-                    
+
                     if (!isspace(current.get()))
                     {
                         return false;
                     }
-                    
+
                     current.increment();
                 }
                 return true;
             }
-            
+
             /**
-             * Read a word started with a double quote character.
+             * Read a word which is quoted via the given quote character.
              */
-            void read_quoted_string(std::vector< std::string >& argv)
+            void read_quoted_string(std::vector< std::string >& argv, char quote_char)
             {
                 current.increment(); // consume "
-                
-                while (current.get() != '"')
+
+                while (current.get() != quote_char)
                 {
                     switch (current.get())
                     {
@@ -559,7 +567,7 @@ namespace soar
                             error = "unexpected eof";
                             current.invalidate();
                             return;
-                            
+
                         case '\\':
                         {
                             char c = parse_escape_sequence();
@@ -570,17 +578,17 @@ namespace soar
                             argv.back().push_back(c);
                         }
                         break;
-                        
+
                         default:
                             argv.back().push_back(current.get());
                             current.increment();
                             break;
                     }
                 }
-                
-                current.increment(); // consume "
+
+                current.increment(); // consume quote_char
             }
-            
+
             /**
              * The current character is a backslash, return the next character
              * converting it if necessary.  Special codes become new characters
@@ -590,9 +598,9 @@ namespace soar
             char parse_escape_sequence()
             {
                 current.increment(); // consume backslash
-                
+
                 // future work? newline, octal, hex, wide hex
-                
+
                 char ret = 0;
                 bool increment = true;
                 switch (current.get())
@@ -637,7 +645,7 @@ namespace soar
                 }
                 return ret;
             }
-            
+
             /**
              * Read a word enclosed in braces. Brace levels must match unless
              * braces are escaped.
@@ -701,7 +709,7 @@ namespace soar
                     }
                 }
             }
-            
+
             /**
              * Skip whitespace and a comment (to the end of the line) if a pound
              * sign is encountered.
@@ -721,7 +729,7 @@ namespace soar
                         break;
                 }
             }
-            
+
             /**
              * Read until first non-whitespace character.
              */
@@ -732,7 +740,7 @@ namespace soar
                     current.increment();
                 }
             }
-            
+
             /**
              * Read until newline and consume the newline.
              */


### PR DESCRIPTION
When the CLI tokenizer was refactored between 9.2 and 9.3, the logic
for reading words enclosed in pipes was removed, though the
requirement that pipes match was kept inside of curly brace blocks.

Add back the capability to read pipe words, mostly using the existing
functionality for double-quotes. Pipes, unlike double quotes, need to
be saved in the output word in order to be used by the lexer.
