### PR TITLE
Automated build testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the development branch
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install requirements
+        run: sudo apt-get tcl-dev
+      - name: Build everything
+        run: python scons/scons.py all
+
+      # Runs a set of commands using the runners shell
+      - name: Run tests 
+        run: |
+          cd out
+          ./UnitTests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install requirements
-        run: sudo apt-get tcl-dev
+        run: sudo apt-get install tcl-dev
       - name: Build everything
         run: python scons/scons.py all
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: Install requirements
         run: sudo apt-get install tcl-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,6 +15,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,11 +4,9 @@ name: Build
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the development branch
+  # Triggers the workflow on push or pull request events
   push:
-    branches: [ development ]
   pull_request:
-    branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build
+name: Linux Build
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build
+name: MacOS Build
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,34 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the development branch
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install requirements
+        run: brew install swig --cask tcl
+      - name: Build everything
+        run: python scons/scons.py all
+      - name: Run tests 
+        run: |
+          cd out
+          ./UnitTests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: Install requirements
         run: brew install --cask tcl; brew install swig

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,11 +4,9 @@ name: Build
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the development branch
+  # Triggers the workflow on push or pull request events
   push:
-    branches: [ development ]
   pull_request:
-    branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install requirements
-        run: brew install swig --cask tcl
+        run: brew install --cask tcl; brew install swig
       - name: Build everything
         run: python scons/scons.py all
       - name: Run tests 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the development branch
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install requirements
+        run: choco install activetcl swig
+      - name: Build everything
+        run: build all
+      - name: Run tests 
+        run: |
+          cd out
+          ./UnitTests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,10 +23,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Start powershell
+        run: powershell
       - name: Install requirements
         run: choco install activetcl swig
       - name: Build everything
-        run: build all
+        run: ./build.bat all
       - name: Run tests 
         run: |
           cd out

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       
       - name: Install requirements
-        run: choco install magicsplat-tcl-tk swig
+        run: choco install magicsplat-tcl-tk swig --limit-output --params="'/i "msi path" TARGETDIR="C:\Tcl" /qb'"
       - name: Build everything
         run: ./build.bat all
       - name: Run tests 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build
+name: Windows Build
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,10 +26,18 @@ jobs:
           python-version: 3.8
       - uses: ilammy/msvc-dev-cmd@v1
       
+      # install dependencies
+      # refresh env vars so can find tcl on the path
+      # find tclsh, which will be in something like c:\<tcllocation>\bin\tclsh.exe
+      # get the parent parent directory to get c:\<tcllocation>, and create a symlink to make that
+      # appear at c:\Tcl, which is where the scons script expects it on windows
       - name: Install requirements
         run: |
-            choco install magicsplat-tcl-tk --no-progress --install-args="'TARGETDIR="C:\Tcl" /qb'"
+            choco install magicsplat-tcl-tk --no-progress
             choco install swig --no-progress
+            refreshenv
+            $tclPath = split-path (split-path (get-command tclsh).Path)
+            cmd /c mklink /d c:\Tcl $tclPath
       - name: Build everything
         run: ./build.bat all
       - name: Run tests 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,11 +4,9 @@ name: Build
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the development branch
+  # Triggers the workflow on push or pull request events
   push:
-    branches: [ development ]
   pull_request:
-    branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       
       - name: Install requirements
-        run: choco install activetcl swig
+        run: choco install magicsplat-tcl-tk swig
       - name: Build everything
         run: ./build.bat all
       - name: Run tests 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       
       - name: Install requirements
-        run: choco install magicsplat-tcl-tk swig --limit-output --params="'/i "msi path" TARGETDIR="C:\Tcl" /qb'"
+        run: |
+            choco install magicsplat-tcl-tk --no-progress --install-args="'/i "msi path" TARGETDIR="C:\Tcl" /qb'"
+            choco install swig --no-progress
       - name: Build everything
         run: ./build.bat all
       - name: Run tests 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       
       - name: Install requirements
         run: |
-            choco install magicsplat-tcl-tk --no-progress --install-args="'/i "msi path" TARGETDIR="C:\Tcl" /qb'"
+            choco install magicsplat-tcl-tk --no-progress --install-args="'TARGETDIR="C:\Tcl" /qb'"
             choco install swig --no-progress
       - name: Build everything
         run: ./build.bat all

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Start powershell
-        run: powershell
+      
       - name: Install requirements
         run: choco install activetcl swig
       - name: Build everything


### PR DESCRIPTION
I recently set up automated builds / unit testing on [jsoar](https://github.com/soartech/jsoar/actions), so I thought I'd take a stab at doing the same thing for csoar. The goal is to build everything for each of the 3 main OSes, and run `UnitTests` (and possibly some other things should be added here, too). This branch contains the workflow files I created (one each for windows, linux, and macos). I've gotten it to a certain point, but I think to take it the rest of the way requires some actual engineering / build changes.

Here's the current status:
* Windows: Builds and runs the unit tests, some of which fail (as has been previously reported). But it doesn't detect the Tcl installation, so it doesn't build the Tcl stuff. Suggestions here include making the build automatically locate Tcl, similar to how it automatically locates Python and Java.
* Linux + macos: Currently fails during build of the csharp support. Apparently there are some bad casts due to pointer sizes being larger than an unsigned int. I didn't see a way to disable the csharp support (although really, it should be built since we want to ensure everything actually builds). Because the builds fail, it doesn't get to try to run the unit tests.

The workflows are currently set to build on a push / PR on any branch, but arguably we would want to limit this to the `development` branch, if other active branches are typically in broken states. (For testing on this branch, though, it's convenient to have it target all branches.) Another change is to remove the scons limits on the supported java and VS C++ versions that are allowed -- on the `java-compatibility` branch we have already done this, which allows us to use more modern compilers and jvms.

As part of making this work, it's probably worth giving the build instructions an update, as they are a little outdated. A bigger project would be switching from scons to a more mainstream build system -- I recommend cmake, which seems to be what everyone uses these days for cross-platform C++ projects.

You can also get a "badge" for each workflow, which you could put in the README so the build status shows on the main landing page, like this:

![Linux Build](https://github.com/SoarGroup/Soar/workflows/Linux%20Build/badge.svg) ![MacOS Build](https://github.com/SoarGroup/Soar/workflows/MacOS%20Build/badge.svg) ![Windows Build](https://github.com/SoarGroup/Soar/workflows/Windows%20Build/badge.svg) 