### PR TITLE
editing improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# no particular reason, just specifying how our files are currently formatted
+[*.soar]
+indent_size = 3

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+venv
 
 # C extensions
 *.so
@@ -349,7 +350,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -471,6 +472,9 @@ tmp/
 local.properties
 .settings/
 .loadpath
+
+# IDEA
+.idea/
 
 # Eclipse Core
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+compile_commands.json
 
 # Visual Studo 2015 cache/options directory
 .vs/


### PR DESCRIPTION
* Ignore venv, which some editors will ask you to generate for working with the SConstruct files
* Add .editorconfig to help maintain basic consistency in future changes
* Generate compile_commands.json so the C++ project can be loaded in other IDE's