### PR TITLE
fix missing junit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 # no particular reason, just specifying how our files are currently formatted
 [*.soar]
 indent_size = 3
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,18 @@ jobs:
 
       - name: unit tests
         working-directory: ./out
-        run: ./UnitTests -e PRIMS_Sanity1 -e PRIMS_Sanity2 -f testSmemArithmetic && junit TestResults.xml
+        run: ./UnitTests -e PRIMS_Sanity1 -e PRIMS_Sanity2 -f testSmemArithmetic
+
+      # reports JUnit test results as GitHub PR check.
+      - name: publish test report
+        uses: mikepenz/action-junit-report@v3
+        # always run even if the previous step fails
+        if: always()
+        with:
+          report_paths: './out/TestResults.xml'
+          # disabled until https://github.com/mikepenz/action-junit-report/issues/40 is resolved
+          # fail_on_failure: true
+          annotate_only: true
       # TODO: run Python SML test
 
   Windows:
@@ -96,5 +107,17 @@ jobs:
 
       - name: unit tests
         working-directory: ./out
-        run: ./UnitTests -e PRIMS_Sanity1 -e PRIMS_Sanity2 -f testSmemArithmetic && junit TestResults.xml
+        run: ./UnitTests -e PRIMS_Sanity1 -e PRIMS_Sanity2 -f testSmemArithmetic
+
+      # reports JUnit test results as GitHub PR check.
+      - name: publish test report
+        uses: mikepenz/action-junit-report@v3
+        # always run even if the previous step fails
+        if: always()
+        with:
+          report_paths: './out/TestResults.xml'
+          # disabled until https://github.com/mikepenz/action-junit-report/issues/40 is resolved
+          # fail_on_failure: true
+          annotate_only: true
+
       # TODO: run Python SML test

--- a/UnitTests/TestHarness/testMain.cpp
+++ b/UnitTests/TestHarness/testMain.cpp
@@ -310,9 +310,11 @@ int main(int argc, char** argv)
                 std::cout.flush();
                 ++expectedFailureCount;
 
-                xml << " >" << std::endl
-                    << "\t\t" << "<failure type=\"Test Failure\">" << runner->failureMessage << "</failure>" << std::endl
-                    << "\t</testcase>" << std::endl;
+                // status="ignored" with the failure message would be more correct,
+                //but our reporting tool can't currently handle this.
+                xml << " status=\"disabled\" />" << std::endl;
+                // << "\t\t" << "<failure type=\"Test Failure\">" << runner->failureMessage << "</failure>" << std::endl
+                // << "\t</testcase>" << std::endl;
             }
             else if (runner->failed)
             {


### PR DESCRIPTION
Builds were failing because `junit` was not installed. Use a dedicated action plugin to ensure it is available and also publish the test report on PR's for convenient viewing.