### PR TITLE
Add `string` RHS function

### DIFF
--- a/Core/KernelSML/src/sml_AgentSML.cpp
+++ b/Core/KernelSML/src/sml_AgentSML.cpp
@@ -1026,7 +1026,7 @@ bool AgentSML::AddDoubleInputWME(char const* pID, char const* pAttribute, double
         ca.Add()->id = pID;
         ca.Add()->attr = pAttribute;
         std::ostringstream valueString;
-        valueString << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
+        valueString << std::setprecision(std::numeric_limits<double>::max_digits10) << std::fixed << value;
         ca.Add()->value = valueString.str();
         ca.Add()->type = sml_Names::kTypeDouble;
         CaptureInputWME(ca);

--- a/Core/SoarKernel/src/soar_representation/rhs_functions.cpp
+++ b/Core/SoarKernel/src/soar_representation/rhs_functions.cpp
@@ -56,6 +56,7 @@
 #include "working_memory.h"
 #include "xml.h"
 
+#include <iomanip>
 #include <map>
 #include <stdlib.h>
 #include <string>
@@ -712,6 +713,10 @@ Symbol* trim_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data*/
     return returnSym;
 }
 
+/**
+ * Convert a symbol of any type to a string symbol representation. Uses Symbol::to_string for all
+ * types except floats, which need special handling to avoid losing precision.
+*/
 Symbol* string_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data*/)
 {
     char* symbol_to_convert;
@@ -729,7 +734,7 @@ Symbol* string_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data
 
     Symbol* sym_to_stringify = (Symbol*) args->first;
 
-    Symbol *returnSym = thisAgent->symbolManager->make_str_constant(sym_to_stringify->to_string());
+    Symbol *returnSym = thisAgent->symbolManager->make_str_constant(sym_to_stringify->to_string(false, false, NIL, 0, std::numeric_limits<double>::max_digits10));
 
     return returnSym;
 }

--- a/Core/SoarKernel/src/soar_representation/rhs_functions.cpp
+++ b/Core/SoarKernel/src/soar_representation/rhs_functions.cpp
@@ -710,8 +710,30 @@ Symbol* trim_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data*/
     returnSym = thisAgent->symbolManager->make_str_constant(str.c_str());
     free(symbol_to_trim);
     return returnSym;
-
 }
+
+Symbol* string_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data*/)
+{
+    char* symbol_to_convert;
+
+    if (!args)
+    {
+        thisAgent->outputManager->printa_sf(thisAgent, "%eError: 'string' function called with no arguments.\n");
+        return NIL;
+    }
+    if (args->rest)
+    {
+        thisAgent->outputManager->printa_sf(thisAgent, "%eError: 'string' takes exactly 1 argument.\n");
+        return NIL;
+    }
+
+    Symbol* sym_to_stringify = (Symbol*) args->first;
+
+    Symbol *returnSym = thisAgent->symbolManager->make_str_constant(sym_to_stringify->to_string());
+
+    return returnSym;
+}
+
 
 Symbol* strlen_rhs_function_code(agent* thisAgent, cons* args, void* /*user_data*/)
 {
@@ -1020,6 +1042,7 @@ void init_built_in_rhs_functions(agent* thisAgent)
     add_rhs_function(thisAgent, thisAgent->symbolManager->make_str_constant("strlen"), strlen_rhs_function_code, 1, true, false, 0, false);
     add_rhs_function(thisAgent, thisAgent->symbolManager->make_str_constant("timestamp"),  timestamp_rhs_function_code, 0, true, false, 0, false);
     add_rhs_function(thisAgent, thisAgent->symbolManager->make_str_constant("trim"),  trim_rhs_function_code, 1, true, false, 0, false);
+    add_rhs_function(thisAgent, thisAgent->symbolManager->make_str_constant("string"), string_rhs_function_code, 1, true, false, 0, true);
 
     /* RHS functions that are more elaborate */
     add_rhs_function(thisAgent, thisAgent->symbolManager->make_str_constant("accept"), accept_rhs_function_code, 0, true, false, 0, false);
@@ -1052,6 +1075,7 @@ void remove_built_in_rhs_functions(agent* thisAgent)
     remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("strlen"));
     remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("timestamp"));
     remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("trim"));
+    remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("string"));
 
     remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("accept"));
     remove_rhs_function(thisAgent, thisAgent->symbolManager->find_str_constant("deep-copy"));

--- a/Core/SoarKernel/src/soar_representation/symbol.cpp
+++ b/Core/SoarKernel/src/soar_representation/symbol.cpp
@@ -227,7 +227,7 @@ char* Symbol::to_string(bool rereadable, bool showLTILink, char* dest, size_t de
                  }
              }
 
-            string_stream << std::setprecision(decimal_precision) << fc->value;
+            string_stream << std::setprecision(decimal_precision) <<  std::fixed << fc->value;
             allocated = make_memory_block_for_string(fc->thisAgent, string_stream.str().c_str());
 
             if (decimal_precision == DEFAULT_DECIMAL_PRECISION)

--- a/Core/SoarKernel/src/soar_representation/symbol.h
+++ b/Core/SoarKernel/src/soar_representation/symbol.h
@@ -16,11 +16,15 @@
 #ifndef SYMTAB_H
 #define SYMTAB_H
 
+// default precision used by std::to_string(double)
+#define DEFAULT_DECIMAL_PRECISION 6
+
 #include "kernel.h"
 
 #include "Export.h"
 
 #include <sstream>
+
 
 /* -- Forward declarations needed for symbol base struct -- */
 
@@ -102,7 +106,7 @@ typedef struct EXPORT symbol_struct
 
     bool        get_id_name(std::string& n);
     void        mark_if_unmarked(agent* thisAgent, tc_number tc, cons** sym_list);
-    char*       to_string(bool rereadable = false, bool showLTILink = false, char* dest = NIL, size_t dest_size = 0);
+    char*       to_string(bool rereadable = false, bool showLTILink = false, char* dest = NIL, size_t dest_size = 0, const int decimal_precision=DEFAULT_DECIMAL_PRECISION);
     void        update_cached_lti_print_str(bool force_creation = false);
 
     struct symbol_struct*   get_parent_state();
@@ -370,7 +374,5 @@ double get_number_from_symbol(Symbol* sym);
  * ms_retractions              DLL of all retractions at this level
  * associated_output_links     Used by the output module
  * input_wmes                  DLL of wmes added by input functions --*/
-
-
 
 #endif

--- a/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
+++ b/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
@@ -1,14 +1,13 @@
 # test string RHS function, including round-trip conversion between string and float/int
-# for floats, we must test more than 6 decimal places to make sure we are preserving full precision
+# for floats, we test as many decimal places as possible to make sure we are preserving full precision
 sp {stringify-values
    (state <s> ^superstate nil <sup>)
 -->
-   (<s> ^sup-string (string <sup>) ^v1 (float (string -1.1234567891234)) ^v2 (int (string 42)) ^v3 (string |hello|))
+   (<s> ^sup-string (string <sup>) ^v1 (float (string -1.12345678912345678)) ^v2 (int (string 42)) ^v3 (string |hello|))
 }
 
 sp {check-values
-   (state <s1> ^sup-string |nil| ^v1 -1.1234567891234 ^v2 42 ^v3 |hello|)
+   (state <s1> ^sup-string |nil| ^v1 -1.12345678912345678 ^v2 42 ^v3 |hello|)
 -->
    (succeeded)
 }
-

--- a/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
+++ b/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
@@ -1,0 +1,22 @@
+sp {set-values
+(state <s> ^superstate nil <sup>)
+-->
+(<s> ^v1 0.01 ^v2 42 ^v3 |hello|)
+}
+
+sp {stringify-values
+(state <s> ^superstate nil <sup>)
+(<s> ^v1 <v1> ^v2 <v2> ^v3 <v3>)
+-->
+(<s> ^sup-string (string <sup>))
+(<s> ^v1-string (string <v1>))
+(<s> ^v2-string (string <v2>))
+(<s> ^v3-string (string <v3>))
+}
+
+sp {monitor*contents
+(state <s1> ^sup-string |nil| ^v1-string |0.010000| ^v2-string |42| ^v3-string |hello|)
+-->
+(succeeded)
+}
+

--- a/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
+++ b/UnitTests/SoarTestAgents/BuiltinRHSTests_testString.soar
@@ -1,22 +1,14 @@
-sp {set-values
-(state <s> ^superstate nil <sup>)
--->
-(<s> ^v1 0.01 ^v2 42 ^v3 |hello|)
-}
-
+# test string RHS function, including round-trip conversion between string and float/int
+# for floats, we must test more than 6 decimal places to make sure we are preserving full precision
 sp {stringify-values
-(state <s> ^superstate nil <sup>)
-(<s> ^v1 <v1> ^v2 <v2> ^v3 <v3>)
+   (state <s> ^superstate nil <sup>)
 -->
-(<s> ^sup-string (string <sup>))
-(<s> ^v1-string (string <v1>))
-(<s> ^v2-string (string <v2>))
-(<s> ^v3-string (string <v3>))
+   (<s> ^sup-string (string <sup>) ^v1 (float (string -1.1234567891234)) ^v2 (int (string 42)) ^v3 (string |hello|))
 }
 
-sp {monitor*contents
-(state <s1> ^sup-string |nil| ^v1-string |0.010000| ^v2-string |42| ^v3-string |hello|)
+sp {check-values
+   (state <s1> ^sup-string |nil| ^v1 -1.1234567891234 ^v2 42 ^v3 |hello|)
 -->
-(succeeded)
+   (succeeded)
 }
 

--- a/UnitTests/SoarUnitTests/BuiltinRHSTests.cpp
+++ b/UnitTests/SoarUnitTests/BuiltinRHSTests.cpp
@@ -1,0 +1,8 @@
+//  Copyright © 2022 University of Michigan – Soar Group. All rights reserved.
+
+#include "BuiltinRHSTests.hpp"
+
+void BuiltinRHSTests::testString()
+{
+    runTest("testString", 0);
+}

--- a/UnitTests/SoarUnitTests/BuiltinRHSTests.hpp
+++ b/UnitTests/SoarUnitTests/BuiltinRHSTests.hpp
@@ -1,0 +1,17 @@
+//  Copyright © 2022 University of Michigan – Soar Group. All rights reserved.
+
+#ifndef BuiltinRHSTests_cpp
+#define BuiltinRHSTests_cpp
+
+#include "FunctionalTestHarness.hpp"
+
+class BuiltinRHSTests : public FunctionalTestHarness
+{
+public:
+    TEST_CATEGORY(BuiltinRHSTests);
+
+    TEST(testString, -1)
+    void testString();
+};
+
+#endif /* BuiltinRHSTests_cpp */

--- a/UnitTests/TestHarness/testMain.cpp
+++ b/UnitTests/TestHarness/testMain.cpp
@@ -22,6 +22,7 @@
 #include "AgentTest.hpp"
 #include "AliasTest.hpp"
 #include "BasicTests.hpp"
+#include "BuiltinRHSTests.hpp"
 #include "ChunkingTests.hpp"
 #include "ChunkingDemoTests.hpp"
 #include "ElementXMLTest.hpp"
@@ -191,6 +192,7 @@ int main(int argc, char** argv)
     TEST_DECLARATION(AgentTest);
     TEST_DECLARATION(AliasTest);
     TEST_DECLARATION(BasicTests);
+    TEST_DECLARATION(BuiltinRHSTests);
     TEST_DECLARATION(ChunkingDemoTests);
     TEST_DECLARATION(ChunkingTests);
     TEST_DECLARATION(EpMemFunctionalTests);


### PR DESCRIPTION
Mostly this a copy of the trim function with most of the code deleted; we don't need to do any manual copying or freeing of strings, since `make_str_constant` does this for us.

Add a new category of unit tests, `BuiltinRHSTests`; I do see some existing tests that exercise the built-in RHS functions, but they are in the `ChunkingTests` category, and we're not testing chunks here.

Fixes #313.