### PR TITLE
Fix incorrect printa_sf calls everywhere

### DIFF
--- a/Core/CLI/src/cli_print.cpp
+++ b/Core/CLI/src/cli_print.cpp
@@ -127,7 +127,7 @@ void print_stack_trace(agent* thisAgent, bool print_states, bool print_operators
 
     if (stateCount > maxStates)
     {
-        thisAgent->outputManager->printa_sf(thisAgent,  "...Stack goes on for another %d states\n", stateCount - maxStates);
+        thisAgent->outputManager->printa_sf(thisAgent,  "...Stack goes on for another %d states\n", static_cast<int64_t>(stateCount - maxStates));
     }
 }
 
@@ -706,7 +706,7 @@ void print_symbol(agent* thisAgent, const char* arg, bool print_filename, bool i
             }
             if (!w)
             {
-                thisAgent->outputManager->printa_sf(thisAgent,  "No wme %u in working memory.", lexeme.int_val);
+                thisAgent->outputManager->printa_sf(thisAgent,  "No wme %d in working memory.", lexeme.int_val);
             }
             break;
 

--- a/Core/KernelSML/src/sml_RunScheduler.cpp
+++ b/Core/KernelSML/src/sml_RunScheduler.cpp
@@ -66,7 +66,7 @@ smlRunStepSize RunScheduler::DefaultInterleaveStepSize(bool forever, smlRunStepS
     {
         return sml_PHASE;
     }
-    
+
     switch (runStepSize)
     {
         case sml_PHASE:
@@ -101,7 +101,7 @@ bool RunScheduler::VerifyStepSizeForRunType(bool forever, smlRunStepSize runStep
                 sml_DECISION == interleave ||
                 sml_UNTIL_OUTPUT == interleave) ;
     }
-    
+
     switch (runStepSize)
     {
         case sml_PHASE:
@@ -139,15 +139,15 @@ static bool IsPhaseLater(smlPhase phase1, smlPhase phase2)
 AgentSML* RunScheduler::GetAgentToSynchronizeWith()
 {
     AgentSML* pSynchAgent = NULL ;
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun())
         {
             AgentSML* pAgent = pAgentSML ;
-            
+
             // What this says is:
             // If we don't have a current synch agent or
             // if this agent is later in decision cycle count or
@@ -161,7 +161,7 @@ AgentSML* RunScheduler::GetAgentToSynchronizeWith()
             }
         }
     }
-    
+
     return pSynchAgent ;
 }
 
@@ -174,14 +174,14 @@ bool RunScheduler::AreAgentsSynchronized(AgentSML* pSynchAgent)
     {
         return true ;
     }
-    
+
     bool same = true ;
     smlPhase phase = pSynchAgent->GetCurrentPhase() ;
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun())
         {
             if (pAgentSML->GetCurrentPhase() != phase)
@@ -190,7 +190,7 @@ bool RunScheduler::AreAgentsSynchronized(AgentSML* pSynchAgent)
             }
         }
     }
-    
+
     return same ;
 }
 
@@ -203,7 +203,7 @@ bool RunScheduler::AllAgentsAtStopBeforePhase()
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun())
         {
             if (pAgentSML->GetCurrentPhase() != m_StopBeforePhase)
@@ -225,26 +225,26 @@ bool RunScheduler::IsAgentFinished(AgentSML* pAgentSML, bool forever, smlRunStep
 {
     uint64_t current = pAgentSML->GetRunCounter(runStepSize) ;
     uint64_t initial = pAgentSML->GetInitialRunCount() ;
-    
+
     uint64_t difference = current - initial ;
-    
-    //fprintf(stdout, "Agent %s current is %d initial is %d diff is %d\n", pAgent->GetName(), current, initial, difference) ; fflush(stdout) ;
-    
+
+    //fprintf(stdout, "Agent %s current is %d initial is %d diff is %d\n", pAgent->GetName(), static_cast<int64_t>(current), static_cast<int64_t>(initial), static_cast<int64_t>(difference)) ; fflush(stdout) ;
+
     bool finished = (difference >= count) && !forever;
-    
-    
+
+
     // if a sml_STOP_AFTER_DECISION_CYCLE is requested,  then
     // agents that are running by Decisions should get marked as finished.
     // They will generate interrupt in MoveTo_StopBeforePhase
-    
+
     if (((sml_DECISION == runStepSize) || forever) && (pAgentSML->GetInterruptFlags() & sml_STOP_AFTER_DECISION_CYCLE))
     {
         finished = true;
     }
-    
+
     // The code that runs an agent to its appropriate StopBeforePhase only runs
     // after all agents Finish the run.  See MoveTo_StopBeforePhase.   KJC 12/05
-    
+
     return finished ;
 }
 
@@ -257,13 +257,13 @@ void RunScheduler::InitializeStepList()
     // We only check the agents that are scheduled to run.
     // This allows us to start <n> agents and have them drop out as they
     // finish one "runStepSize"
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         pAgentSML->PutAgentOnStepList(pAgentSML->IsAgentScheduledToRun()) ;
-        
+
     }
 }
 
@@ -276,17 +276,17 @@ bool RunScheduler::AgentsStillStepping()
     // We only check the agents that are scheduled to run.
     // This allows us to start <n> agents and have them drop out as they
     // finish one "runStepSize"
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun() && pAgentSML->IsAgentOnStepList())
         {
             return true ;
         }
     }
-    
+
     return false ;
 }
 
@@ -298,7 +298,7 @@ void RunScheduler::FireBeforeRunStartsEvents()
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun())
         {
             pAgentSML->FireRunEvent(smlEVENT_BEFORE_RUN_STARTS) ;
@@ -335,7 +335,7 @@ void RunScheduler::InitializeRunCounters(smlRunStepSize runStepSize)
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (pAgentSML->IsAgentScheduledToRun())
         {
             pAgentSML->ResetLastOutputCount() ;
@@ -361,11 +361,11 @@ void RunScheduler::InitializeUpdateWorldEvents(bool addListeners)
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         pAgentSML->SetCompletedOutputPhase(false) ;
         pAgentSML->SetGeneratedOutput(false) ;
         pAgentSML->SetInitialOutputCount(pAgentSML->GetNumOutputsGenerated()) ;
-        
+
         // We register a listener so that the agent counters/flags get updated at the end of Output.
         if (addListeners)
         {
@@ -385,11 +385,11 @@ bool RunScheduler::AreAllOutputPhasesComplete()
     // generate the event.  However, it also means if we do a "run --self" to only run some agents this event will
     // still fire, so we'll need to know not to update the world based on the runFlags.
     bool agents_running = false;
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         // Agents that are halted or interrupted are no longer m_ScheduledToRun
         // Agents that are paused waiting for other agents finish a RunType, are still m_ScheduledToRun
         if (pAgentSML->IsAgentScheduledToRun())
@@ -401,10 +401,10 @@ bool RunScheduler::AreAllOutputPhasesComplete()
             }
         }
     }
-    
+
     // If all running agents completed output, we'll get here.  BUT we could also reach this
     // point if ALL agents are interrupted/halted, and none are m_ScheduledToRun
-    
+
     if (agents_running)
     {
         return true;    // we got here only if there are running agents and they all completed output
@@ -426,11 +426,11 @@ bool RunScheduler::AreAllOutputPhasesComplete()
             }
         }
     }
-    
+
     // IF we're interrupted at the end of Decision_cycle, then we SHOULD return true above,
     // although if somehow we don't, it's possible that agents will SNC one cycle waiting for
     // I/O to catch up.  But if we returned true here, we could get many false positive events.
-    
+
     return false ;
 }
 
@@ -447,7 +447,7 @@ bool RunScheduler::HaveAllGeneratedOutput()
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         // Agents that are halted or interrupted are no longer m_ScheduledToRun
         // Agents that are paused waiting for other agents finish a RunType, are still m_ScheduledToRun
         if (pAgentSML->IsAgentScheduledToRun() && !pAgentSML->HasGeneratedOutput())
@@ -455,7 +455,7 @@ bool RunScheduler::HaveAllGeneratedOutput()
             return false ;
         }
     }
-    
+
     return true ;
 }
 /********************************************************************
@@ -481,7 +481,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
     // cross the I/O boundary.  So we'll try stepping til OUTPUT done, then generate
     // Update events, then step again til StopBeforePt is reached.  Note:  when we support
     // StopBeforeUpdateWorld, we'll need to explicitly check for that before generating events.
-    
+
     if ((runStepSize == sml_DECISION) || forever)
     {
         for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
@@ -492,7 +492,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
                 AgentSML* pAgent = pAgentSML ;
                 smlPhase phase = pAgentSML->GetCurrentPhase() ;
                 smlRunResult runResult = pAgentSML->GetResultOfLastRun() ;
-                
+
                 // as in Bug 648, it's possible that a client has requested STOP_AFTER_DECISION
                 // while the agent was stopped at the m_StopBeforePhase, yet the agent run logic has
                 // dropped thru to this point without generating the interrupt yet.
@@ -502,7 +502,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
                     pAgent->SetRunState(sml_RUNSTATE_INTERRUPTED);
                     runResult = pAgent->StepInClientThread(sml_PHASE) ; // force interrupt
                 }
-                
+
                 while ((phase != m_StopBeforePhase) && (sml_RUN_COMPLETED == runResult))
                 {
                     runResult = pAgent->StepInClientThread(sml_PHASE) ;
@@ -514,7 +514,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
                     }
                 }
                 pAgentSML->SetResultOfRun(runResult) ;
-                
+
                 // Notify listeners that this agent is finished running
                 /* pAgent->FireRunEndsEvent() ; */   // not if supporting run0 over O/I boundary
             }
@@ -523,7 +523,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
         // and we need to possibly generate the UpdateWorld events before stepping any further.
         // If not all agents finished output, then nothing will fire.
         TestForFiringUpdateWorldEvents();
-        
+
         // This second While loop is only needed if we allow agents to cross the
         // output-update-input boundary on a "run 0" command.  If we don't allow that
         // then all that is left to do is generate the RunEndsEvents. (and we shouldn't
@@ -537,7 +537,7 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
                 AgentSML* pAgent = pAgentSML ;
                 smlPhase phase = pAgentSML->GetCurrentPhase() ;
                 smlRunResult runResult = pAgentSML->GetResultOfLastRun() ;
-                
+
                 while ((phase != m_StopBeforePhase) && (sml_RUN_COMPLETED == runResult))
                 {
                     runResult = pAgent->StepInClientThread(sml_PHASE) ;
@@ -545,9 +545,9 @@ void RunScheduler::MoveTo_StopBeforePhase(bool forever, smlRunStepSize runStepSi
                     // We should never get to this point again, so we need to generate ERROR
                     assert(sml_INPUT_PHASE != phase);
                 }
-                
+
                 pAgentSML->SetResultOfRun(runResult) ;
-                
+
                 // Notify listeners that this agent is finished running
                 pAgent->FireRunEvent(smlEVENT_AFTER_RUN_ENDS) ;
             }
@@ -566,7 +566,7 @@ void RunScheduler::TestForFiringUpdateWorldEvents()
     {
         // If so fire the after_all_output_phases event
         m_pKernelSML->FireUpdateListenerEvent(smlEVENT_AFTER_ALL_OUTPUT_PHASES, m_RunFlags) ;
-        
+
         // Then clear the completed output flags so we can repeat the process.
         for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
         {
@@ -578,7 +578,7 @@ void RunScheduler::TestForFiringUpdateWorldEvents()
         {
             // If so fire the after_all_generated_output event
             m_pKernelSML->FireUpdateListenerEvent(smlEVENT_AFTER_ALL_GENERATED_OUTPUT, m_RunFlags) ;
-            
+
             // Then clear the generated output flags and repeat the process.
             for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
             {
@@ -597,7 +597,7 @@ void RunScheduler::TerminateUpdateWorldEvents(bool removeListeners)
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         if (removeListeners)
         {
             pAgentSML->GetAgentRunCallback()->UnregisterWithKernel(smlEVENT_AFTER_OUTPUT_PHASE) ;
@@ -616,7 +616,7 @@ void RunScheduler::TerminateUpdateWorldEvents(bool removeListeners)
 smlRunResult RunScheduler::GetOverallRunResult()
 {
     smlRunResult overallResult = sml_RUN_COMPLETED;
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
@@ -661,19 +661,19 @@ bool RunScheduler::AnAgentHaltedDuringRun()
 bool RunScheduler::TestIfAllFinished(bool forever, smlRunStepSize runStepSize, uint64_t count)
 {
     bool allDone = true ;
-    
+
     for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
     {
         AgentSML* pAgentSML = iter->second ;
-        
+
         bool agentFinishedRun = IsAgentFinished(pAgentSML, forever, runStepSize, count) ;
-        
+
         if (!agentFinishedRun)
         {
             allDone = false ;
         }
     }
-    
+
     return allDone ;
 }
 
@@ -710,40 +710,40 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
     {
         return sml_RUN_ERROR_ALREADY_RUNNING;
     }
-    
+
     // Agents were already appropriately added (or not) to the RunList before calling this method.
     // For every Run Command issued, we can find out if agent is still scheduled to run,
     // and/or whether it was scheduled to run at all.  When agents stop or Halt, the
     // AgentScheduledToRun bool is set to false, but WasScheduledToRun is unchanged.
-    
+
     // We store this as a member so we can access it in gSKI event handlers
     m_RunFlags = runFlags ;
-    
+
     // Stored as a member so agents created on the fly can init themselves with it
     m_CurrentRunStepSize = runStepSize;
-    
+
     // Make sure the args of the Run command are valid.
     VerifyStepSizeForRunType(forever, runStepSize, interleaveStepSize) ;
-    
+
     // Record initial counts and zero the local "run" counter (that we're about to be incrementing)
     InitializeRunCounters(runStepSize) ;
-    
+
     // Depending on RunType, set the stop location for gSKI_STOP_AFTER_DECISION_CYCLE interrupts
     m_pKernelSML->SetStopPoint(forever, runStepSize, m_StopBeforePhase);
-    
+
     // Fire one event to indicate the entire system is starting
     m_pKernelSML->FireSystemEvent(smlEVENT_SYSTEM_START) ;
-    
+
     // IF we did a StopBeforeUpdate, this is where we need to test and generate update events...
     TestForFiringUpdateWorldEvents();
-    
+
     // Initialize state required for update world events
     // Should we do this even if previous Run was interrupted?  Probably not.
     InitializeUpdateWorldEvents(true) ;
-    
+
     // Send event for each agent to signal its about to start running
     FireBeforeRunStartsEvents() ;
-    
+
     bool runFinished = false ;
     uint64_t stepCount   = 0 ;
     //uint64_t runCount    = 0 ;
@@ -756,14 +756,14 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
             pAgentSML->SetResultOfRun(sml_RUN_COMPLETED) ;
         }
     }
-    
+
     m_pKernelSML->ClearAllInterrupts();
-    
+
     // Record that we're now running, so we can poll for our status during a run.
     m_IsRunning = true ;
-    
+
     int interruptCheckRate = m_pKernelSML->GetInterruptCheckRate() ;
-    
+
     // If we need to synchronize agents, we'll set the synchAgent pointer.
     // Otherwise, we'll clear it to indicate no synch needed.
     // This only matters when interleaving by Phases, since SoarKernel methods
@@ -774,13 +774,13 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
     {
         AgentSML* pSynchAgentSML = this->GetAgentToSynchronizeWith() ;
         bool inSynch = AreAgentsSynchronized(pSynchAgentSML) ;
-        
+
         if (!inSynch)
         {
             m_pSynchAgentSML = pSynchAgentSML ;
         }
     }
-    
+
     //  Before running, check to see if an agent is at a point other than the StopBeforePhase.
     //  If so, we'll decrement  the RunCount before entering the Run loop so
     //  as not to run more Decision phases than specified in the runCount.  See bug #710.
@@ -789,28 +789,28 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
         {
             count--;
         }
-        
-        
+
+
     // If we issue a "run 0" and all agents are synched and in the correct state we're done.
     if (!m_pSynchAgentSML && TestIfAllFinished(forever, runStepSize, count))
     {
         runFinished = true ;
     }
-    
+
     if (0 == count)
     {
         runFinished = true;
     }
-    
+
     // Run all agents that have previously been marked as "scheduled to run".
     while (!runFinished)
     {
         // Assume it is finished until proven otherwise
         runFinished = true ;
-        
+
         //initialize stepList = copy of agentRunList
         InitializeStepList();
-        
+
         // while not all agents have complete one RunType (agents still on stepList)
         while (AgentsStillStepping())
         {
@@ -821,31 +821,31 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
             {
                 m_pKernelSML->FireSystemEvent(smlEVENT_INTERRUPT_CHECK) ;
             }
-            
+
             // Handy place to pump messages
             m_pKernelSML->ReceiveAllMessages();
-            
+
             stepCount++ ;
-            
+
             // Notify listeners that Soar is going to run.  This event is a kernel level (agent manager) event
             // which allows a single listener to check for client driven interrupts for all agents.
             // Sometimes that's easier to work with than the agent specific events (where you get <n> events from <n> agents)
             //    note that there is not a corresponding AFTER_AGENTS_RUN_STEP event...
             m_pKernelSML->FireSystemEvent(smlEVENT_BEFORE_AGENTS_RUN_STEP) ;
-            
+
             for (AgentMapIter iter = m_pKernelSML->m_AgentMap.begin() ; iter != m_pKernelSML->m_AgentMap.end() ; iter++)
             {
                 AgentSML* pAgentSML = iter->second ;
-                
+
                 if (pAgentSML->IsAgentOnStepList())
                 {
                     // Run all agents one "interleaveStepSize".
                     smlRunResult runResult = pAgentSML->StepInClientThread(interleaveStepSize) ;
                     // ?? pAgentSML->IncrementLocalStepCounter();
-                    
+
                     // halted and running agents will return an error from StepInClientThread
                     //
-                    
+
                     // if agent finished one runType, incr counter and remove from stepList
                     if (pAgentSML->CompletedRunType(pAgentSML->GetRunCounter(runStepSize)) /* || pAgent->MaxNilOutputCyclesReached */)
                     {
@@ -856,16 +856,16 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
                     {
                         runFinished = false;
                     }
-                    
+
                     // if agent finished count runTypes, remove from RunList, else runFinished = false;
                     // can also return true if a gSKI_STOP_AFTER_DECISION_CYCLE interrupt occurred
                     // or is pending on agents with RunType DECISION or FOREVER.
                     bool agentFinishedRun = IsAgentFinished(pAgentSML, forever, runStepSize, count) ;
-                    
+
                     // Have to test the run state to find out if we are still ok to keep running
                     // (not sure if runResult provides this as well, but they're from different enums).
                     smlRunState runState = pAgentSML->GetRunState() ;
-                    
+
                     // An agent should return "stopped" if it's just pausing in the middle of a run
                     // before we run it for the next phase.  Anything else means this agent is done running.
                     if (runState != sml_RUNSTATE_STOPPED || agentFinishedRun)
@@ -892,31 +892,31 @@ smlRunResult RunScheduler::RunScheduledAgents(bool forever, smlRunStepSize runSt
         //  KJC Is this where we might want to add a "phase" for StopBeforePhase?
         //  We'd need to use m_AllGeneratedOutputEventFired
         TestForFiringUpdateWorldEvents();
-        
+
         // Check for whether the kernel events requested a stop-soar.
         if (TestIfAllFinished(forever, runStepSize, count))
         {
             runFinished = true ;
         }
-        
+
     }  // END of While (!runFinished)
-    
+
     // kernel events might fire in next method...
     MoveTo_StopBeforePhase(forever, runStepSize);  // agents will have done FireRunEndsEvent() here or above.
-    
+
     // Fire one event to indicate the entire system should stop.
     m_pKernelSML->FireSystemEvent(smlEVENT_SYSTEM_STOP) ;
-    
+
     // clean up
     m_IsRunning = false ;
-    
+
     // Clean up anything stored for update world events
     TerminateUpdateWorldEvents(true) ;
-    
+
     // Not sure how to quantify the results of running <n> agents in a single value
     // You can query each agent for its GetResultOfRun() to know more.
-    
+
     overallResult = GetOverallRunResult();
-    
+
     return overallResult ;
 }

--- a/Core/SoarKernel/src/decision_process/consistency.cpp
+++ b/Core/SoarKernel/src/decision_process/consistency.cpp
@@ -773,8 +773,8 @@ void determine_highest_active_production_level_in_stack_apply(agent* thisAgent)
     }
 
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-    printf("\nHighest level of activity is....%d", thisAgent->active_level);
-    printf("\n   Previous level of activity is....%d", thisAgent->previous_active_level);
+    printf("\nHighest level of activity is....%d", static_cast<int64_t>(thisAgent->active_level));
+    printf("\n   Previous level of activity is....%d", static_cast<int64_t>(thisAgent->previous_active_level));
 #endif
 
     if (!thisAgent->active_goal)
@@ -831,7 +831,7 @@ void determine_highest_active_production_level_in_stack_apply(agent* thisAgent)
             if (minor_quiescence_at_goal(thisAgent, thisAgent->previous_active_goal))
             {
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-                printf("\nMinor quiescence at level %d", thisAgent->previous_active_level);
+                printf("\nMinor quiescence at level %d", static_cast<int64_t>(thisAgent->previous_active_level));
 #endif
                 if (!goal_stack_consistent_through_goal(thisAgent, thisAgent->previous_active_goal))
                 {
@@ -888,7 +888,7 @@ void determine_highest_active_production_level_in_stack_apply(agent* thisAgent)
             if (minor_quiescence_at_goal(thisAgent, thisAgent->active_goal))
             {
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-                printf("\nMinor quiescence at level %d", thisAgent->active_level);
+                printf("\nMinor quiescence at level %d", static_cast<int64_t>(thisAgent->active_level));
 #endif
                 if (!goal_stack_consistent_through_goal(thisAgent, thisAgent->active_goal))
                 {
@@ -931,7 +931,7 @@ void determine_highest_active_production_level_in_stack_apply(agent* thisAgent)
                productions there */
 
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-            printf("\nMinor quiescence at level %d", thisAgent->active_level);
+            printf("\nMinor quiescence at level %d", static_cast<int64_t>(thisAgent->active_level));
 #endif
             if (!goal_stack_consistent_through_goal(thisAgent, thisAgent->active_goal))
             {
@@ -1042,8 +1042,8 @@ void determine_highest_active_production_level_in_stack_propose(agent* thisAgent
     }
 
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-    printf("\nHighest level of activity is....%d", thisAgent->active_level);
-    printf("\n   Previous level of activity is....%d", thisAgent->previous_active_level);
+    printf("\nHighest level of activity is....%d", static_cast<int64_t>(thisAgent->active_level));
+    printf("\n   Previous level of activity is....%d", static_cast<int64_t>(thisAgent->previous_active_level));
 #endif
 
     if (!thisAgent->active_goal)
@@ -1145,7 +1145,7 @@ void determine_highest_active_production_level_in_stack_propose(agent* thisAgent
                productions there */
 
 #ifdef DEBUG_DETERMINE_LEVEL_PHASE
-            printf("\nMinor quiescence at level %d", thisAgent->active_level);
+            printf("\nMinor quiescence at level %d",static_cast<int64_t>( thisAgent->active_level));
 #endif
             if (!goal_stack_consistent_through_goal(thisAgent, thisAgent->active_goal))
             {

--- a/Core/SoarKernel/src/decision_process/decide.cpp
+++ b/Core/SoarKernel/src/decision_process/decide.cpp
@@ -71,7 +71,7 @@ void print_candidates(agent* thisAgent, preference* candidates)
     for (cand = candidates; cand != NIL; cand = cand->next_candidate)
     {
         max_count++;
-        thisAgent->outputManager->printa_sf(thisAgent, "\n Candidate %d", cand);
+        thisAgent->outputManager->printa_sf(thisAgent, "\n Candidate %p", cand);
         thisAgent->outputManager->printa_sf(thisAgent, "\n    %y %y %y", cand->id, cand->attr, cand->value);
         if (max_count > 10)
         {

--- a/Core/SoarKernel/src/decision_process/rete.cpp
+++ b/Core/SoarKernel/src/decision_process/rete.cpp
@@ -5912,7 +5912,7 @@ void p_node_left_addition(agent* thisAgent, rete_node* node, token* tok, wme* w)
     /* initialize goal regardless of run mode */
     msc->level = NO_WME_LEVEL;
     msc->goal = NIL;
-    
+
     /*  (this is a RCHONG comment, but might also apply to Operand2...?)
 
     what we have to do now is to, essentially, determine the kind of
@@ -6011,7 +6011,7 @@ void p_node_left_addition(agent* thisAgent, rete_node* node, token* tok, wme* w)
                 elaborations (<o> ^attr ^value) are IE_PROD.  If prod has
                 both operator applications and <o> elabs, then it's PE_PROD
                 and the user is warned that <o> elabs will be o-supported. */
-                
+
                 op_elab = false;
                 lowest_goal_wme = NIL;
 
@@ -6172,7 +6172,7 @@ void p_node_left_addition(agent* thisAgent, rete_node* node, token* tok, wme* w)
         // on the assertion list, Soar will still halt, but the production
         // named will be inaccurate.
         thisAgent->outputManager->printa_sf(thisAgent, "\n*** Production match-time interrupt (:interrupt), probably from %y\n", node->b.p.prod->name);
-        thisAgent->outputManager->printa_sf(thisAgent, "    [Phase] (Interrupt, Stop) is [%d] (%d,%d)\n", thisAgent->current_phase, node->b.p.prod->interrupt, thisAgent->stop_soar);
+        thisAgent->outputManager->printa_sf(thisAgent, "    [Phase] (Interrupt, Stop) is [%d] (%d,%d)\n", static_cast<int64_t>(thisAgent->current_phase), static_cast<int64_t>(node->b.p.prod->interrupt), static_cast<int64_t>(thisAgent->stop_soar));
 
         thisAgent->reason_for_stopping = ":interrupt";
     }
@@ -6220,7 +6220,7 @@ void p_node_left_removal(agent* thisAgent, rete_node* node, token* tok, wme* w)
                 thisAgent->stop_soar = false;
                 if (thisAgent->trace_settings[TRACE_ASSERTIONS_SYSPARAM])
                 {
-                    thisAgent->outputManager->printa_sf(thisAgent, "RETRACTION (1) reset interrupt to READY -- (Interrupt, Stop) to (%d, %d)\n", node->b.p.prod->interrupt, thisAgent->stop_soar);
+                    thisAgent->outputManager->printa_sf(thisAgent, "RETRACTION (1) reset interrupt to READY -- (Interrupt, Stop) to (%d, %d)\n", static_cast<int64_t>(node->b.p.prod->interrupt), static_cast<int64_t>(thisAgent->stop_soar));
                 }
             }
 
@@ -6312,7 +6312,7 @@ void p_node_left_removal(agent* thisAgent, rete_node* node, token* tok, wme* w)
             for (assertion = thisAgent->ms_retractions;  assertion; assertion = assertion->next)
             {
                 thisAgent->outputManager->printa_sf(thisAgent, "     Retraction: %y ", assertion->p_node->b.p.prod->name);
-                thisAgent->outputManager->printa_sf(thisAgent, " at level %d\n", assertion->level);
+                thisAgent->outputManager->printa_sf(thisAgent, " at level %d\n", static_cast<int64_t>(assertion->level));
             }
 
             if (thisAgent->nil_goal_retractions)
@@ -6322,7 +6322,7 @@ void p_node_left_removal(agent* thisAgent, rete_node* node, token* tok, wme* w)
                 for (assertion = thisAgent->nil_goal_retractions; assertion; assertion = assertion->next_in_level)
                 {
                     thisAgent->outputManager->printa_sf(thisAgent, "     Retraction: %y ", assertion->p_node->b.p.prod->name);
-                    thisAgent->outputManager->printa_sf(thisAgent, " at level %d\n", assertion->level);
+                    thisAgent->outputManager->printa_sf(thisAgent, " at level %d\n", static_cast<int64_t>(assertion->level));
                     if (assertion->goal)
                     {
                         thisAgent->outputManager->printa_sf(thisAgent, "This assertion has non-NIL goal pointer.\n");
@@ -7897,7 +7897,7 @@ bool load_rete_net(agent* thisAgent, FILE* source_file)
             rete_net_64 = true; // used by reteload_eight_bytes
             break;
         default:
-            thisAgent->outputManager->printa_sf(thisAgent, "This file is in a format (version %d) I don't understand.\n", format_version_num);
+            thisAgent->outputManager->printa_sf(thisAgent, "This file is in a format (version %d) I don't understand.\n", static_cast<int64_t>(format_version_num));
             return false;
     }
 
@@ -8044,7 +8044,7 @@ void get_all_node_count_stats(agent* thisAgent)
     //for (i=0; i<256; i++)
     //  if (thisAgent->rete_node_counts[i] &&
     //      (*bnode_type_names[i] == 0)) {
-    //    thisAgent->OutputManager->print( "Internal eror: unknown node type [%d] has nonzero count.\n",i);
+    //    thisAgent->OutputManager->print( "Internal eror: unknown node type [%d] has nonzero count.\n", static_cast<int64_t>(i));
     //  }
     init_bnode_type_names(thisAgent);
 
@@ -8496,7 +8496,7 @@ void print_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 thisAgent->outputManager->printa_sf(thisAgent, " [%y] ", tmp->goal);
                 if (tmp->count > 1)
                 {
-                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", tmp->count);
+                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 }
                 else
                 {
@@ -8558,7 +8558,7 @@ void print_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 thisAgent->outputManager->printa_sf(thisAgent, " [%y] ", tmp->goal);
                 if (tmp->count > 1)
                 {
-                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", tmp->count);
+                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 }
                 else
                 {
@@ -8626,7 +8626,7 @@ void print_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 }
                 if (tmp->count > 1)
                 {
-                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", tmp->count);
+                    thisAgent->outputManager->printa_sf(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 }
                 else
                 {
@@ -9061,7 +9061,7 @@ void xml_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 See 2.110 in the OPERAND-CHANGE-LOG. */
                 //thisAgent->outputManager->printa_sf(thisAgent, " [%y] ", tmp->goal);
                 //if (tmp->count > 1)
-                //  print(thisAgent, "(%d)\n", tmp->count);
+                //  print(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 //else
                 //  print(thisAgent, "\n");
                 thisAgent->memoryManager->free_memory(tmp, MISCELLANEOUS_MEM_USAGE);
@@ -9134,7 +9134,7 @@ void xml_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 See 2.110 in the OPERAND-CHANGE-LOG. */
                 //thisAgent->outputManager->printa_sf(thisAgent, " [%y] ", tmp->goal);
                 //if (tmp->count > 1)
-                //  print(thisAgent, "(%d)\n", tmp->count);
+                //  print(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 //else
                 //  print(thisAgent, "\n");
 
@@ -9211,7 +9211,7 @@ void xml_match_set(agent* thisAgent, wme_trace_type wtt, ms_trace_type mst)
                 //else
                 //  print(thisAgent, " [NIL] ");
                 //if(tmp->count > 1)
-                //  print(thisAgent, "(%d)\n", tmp->count);
+                //  print(thisAgent, "(%d)\n", static_cast<int64_t>(tmp->count));
                 //else
                 //  print(thisAgent, "\n");
                 thisAgent->memoryManager->free_memory(tmp, MISCELLANEOUS_MEM_USAGE);

--- a/Core/SoarKernel/src/decision_process/run_soar.cpp
+++ b/Core/SoarKernel/src/decision_process/run_soar.cpp
@@ -161,7 +161,7 @@ void set_trace_setting(agent* thisAgent, int param_number, int64_t new_value)
 {
     if ((param_number < 0) || (param_number > HIGHEST_SYSPARAM_NUMBER))
     {
-        thisAgent->outputManager->printa_sf(thisAgent,  "Internal error: tried to set bad trace param #: %d\n", param_number);
+        thisAgent->outputManager->printa_sf(thisAgent,  "Internal error: tried to set bad trace param #: %d\n", static_cast<int64_t>(param_number));
         return;
     }
     thisAgent->trace_settings[param_number] = new_value;

--- a/Core/SoarKernel/src/episodic_memory/episodic_memory.cpp
+++ b/Core/SoarKernel/src/episodic_memory/episodic_memory.cpp
@@ -2941,7 +2941,7 @@ void epmem_new_episode(agent* thisAgent)
     epmem_time_id time_counter = thisAgent->EpMem->epmem_stats->time->get_value();
 
     // provide trace output
-    print_sysparam_trace(thisAgent, TRACE_EPMEM_SYSPARAM,  "New episodic memory recorded for time %u.\n", static_cast<long int>(time_counter));
+    print_sysparam_trace(thisAgent, TRACE_EPMEM_SYSPARAM,  "New episodic memory recorded for time %u.\n", static_cast<uint64_t>(time_counter));
 
     // perform storage
     {
@@ -4840,7 +4840,7 @@ void epmem_process_query(agent* thisAgent, Symbol* state, Symbol* pos_query, Sym
                     epmem_print_retrieval_state(literal_cache, pedge_caches, uedge_caches);
                 }
 
-                print_sysparam_trace(thisAgent, TRACE_EPMEM_SYSPARAM, "Considering episode (time, cardinality, score) (%u, %u, %f)\n", static_cast<long long int>(current_episode), current_cardinality, current_score);
+                print_sysparam_trace(thisAgent, TRACE_EPMEM_SYSPARAM, "Considering episode (time, cardinality, score) (%u, %u, %f)\n", static_cast<uint64_t>(current_episode), static_cast<uint64_t>(current_cardinality), current_score);
 
                 // if
                 // * the current time is still before any new intervals

--- a/Core/SoarKernel/src/explanation_memory/action_record.cpp
+++ b/Core/SoarKernel/src/explanation_memory/action_record.cpp
@@ -287,9 +287,9 @@ void action_record::print_chunk_action(action* pAction, int lActionCount)
     {
         tempString = "";
         outputManager->rhs_value_to_string(pAction->value, tempString, true, NULL, NULL, true);
-        outputManager->printa_sf(thisAgent, "%d:%-%s", lActionCount,  tempString.c_str());
+        outputManager->printa_sf(thisAgent, "%d:%-%s", static_cast<int64_t>(lActionCount),  tempString.c_str());
     } else {
-        outputManager->printa_sf(thisAgent, "%d:%-(", lActionCount);
+        outputManager->printa_sf(thisAgent, "%d:%-(", static_cast<int64_t>(lActionCount));
         print_rhs_chunk_value(pAction->id, (variablized_action ? variablized_action->id : NULL), true);
         outputManager->printa(thisAgent, " ^");
         print_rhs_chunk_value(pAction->attr, (variablized_action ? variablized_action->attr : NULL), true);
@@ -327,9 +327,9 @@ void action_record::print_instantiation_action(action* pAction, int lActionCount
     {
         tempString = "";
         outputManager->rhs_value_to_string(pAction->value, tempString, true, NULL, NULL, true);
-        outputManager->printa_sf(thisAgent, "%d:%-%s", lActionCount,  tempString.c_str());
+        outputManager->printa_sf(thisAgent, "%d:%-%s", static_cast<int64_t>(lActionCount),  tempString.c_str());
     } else {
-        outputManager->printa_sf(thisAgent, "%d:%-(", lActionCount);
+        outputManager->printa_sf(thisAgent, "%d:%-(", static_cast<int64_t>(lActionCount));
         print_rhs_instantiation_value(pAction->id, NULL, instantiated_pref->inst_identities.id, instantiated_pref->chunk_inst_identities.id, true);
         outputManager->printa(thisAgent, " ^");
         print_rhs_instantiation_value(pAction->attr, NULL, instantiated_pref->inst_identities.attr, instantiated_pref->chunk_inst_identities.attr, true);

--- a/Core/SoarKernel/src/explanation_memory/explain_print.cpp
+++ b/Core/SoarKernel/src/explanation_memory/explain_print.cpp
@@ -41,20 +41,20 @@ void Explanation_Memory::print_formation_explanation()
     if (current_discussed_chunk->result_inst_records->size() > 0)
     {
         outputManager->printa_sf(thisAgent, "The following %d instantiations fired to produce results...\n\n------\n\n",
-        current_discussed_chunk->result_inst_records->size() + 1);
+        static_cast<int64_t>(current_discussed_chunk->result_inst_records->size() + 1));
     }
 
     outputManager->printa_sf(thisAgent, "Initial base instantiation (i %u) that fired when %y matched at level %d at time %u:\n\n",
         current_discussed_chunk->baseInstantiation->instantiationID,
         current_discussed_chunk->baseInstantiation->production_name,
-        current_discussed_chunk->baseInstantiation->match_level,
+        static_cast<int64_t>(current_discussed_chunk->baseInstantiation->match_level),
         current_discussed_chunk->time_formed);
 
     print_instantiation_explanation(current_discussed_chunk->baseInstantiation, false);
 
     if (current_discussed_chunk->result_inst_records->size() > 0)
     {
-        outputManager->printa_sf(thisAgent, "\n%d instantiation(s) that created extra results indirectly because they were connected to the results of the base instantiation:\n\n", (current_discussed_chunk->result_inst_records->size() - 1));
+        outputManager->printa_sf(thisAgent, "\n%d instantiation(s) that created extra results indirectly because they were connected to the results of the base instantiation:\n\n", static_cast<int64_t>((current_discussed_chunk->result_inst_records->size() - 1)));
         for (auto it = current_discussed_chunk->result_inst_records->begin(); it != current_discussed_chunk->result_inst_records->end(); ++it)
         {
             print_instantiation_explanation((*it), false);
@@ -158,7 +158,7 @@ void Explanation_Memory::print_chunk_actions(action_record_list* pActionRecords,
             ++lActionCount;
             if (!print_explanation_trace)
             {
-                outputManager->printa_sf(thisAgent, "%d:%-%p\n", lActionCount, lAction->instantiated_pref);
+                outputManager->printa_sf(thisAgent, "%d:%-%p\n", static_cast<int64_t>(lActionCount), lAction->instantiated_pref);
             } else {
                 while (rhs && (rhs->type == FUNCALL_ACTION))
                 {
@@ -211,7 +211,7 @@ void Explanation_Memory::print_instantiation_actions(action_record_list* pAction
             ++lActionCount;
             if (!print_explanation_trace)
             {
-                outputManager->printa_sf(thisAgent, "%d:%-%p\n", lActionCount, lAction->instantiated_pref);
+                outputManager->printa_sf(thisAgent, "%d:%-%p\n", static_cast<int64_t>(lActionCount), lAction->instantiated_pref);
             } else {
                 while (rhs && (rhs->type == FUNCALL_ACTION))
                 {
@@ -270,7 +270,7 @@ void Explanation_Memory::print_explain_summary()
     outputManager->printa(thisAgent,      "=======================================================\n");
     outputManager->printa_sf(thisAgent,   "Watch all chunk formations        %-%s\n", (m_all_enabled ? "Yes" : "No"));
     outputManager->printa_sf(thisAgent,   "Explain justifications            %-%s\n", (m_justifications_enabled ? "Yes" : "No"));
-    outputManager->printa_sf(thisAgent,   "Number of specific rules watched  %-%d\n", num_rules_watched);
+    outputManager->printa_sf(thisAgent,   "Number of specific rules watched  %-%d\n", static_cast<int64_t>(num_rules_watched));
 
     /* Print specific watched rules and time interval when watch all disabled */
     if (!m_all_enabled)

--- a/Core/SoarKernel/src/explanation_memory/identity_record.cpp
+++ b/Core/SoarKernel/src/explanation_memory/identity_record.cpp
@@ -147,7 +147,7 @@ void identity_record::print_identity_mappings_for_instantiation(instantiation_re
 
 void identity_record::print_identities_in_chunk()
 {
-    thisAgent->outputManager->printa_sf(thisAgent, "\nLearned rule contained %u identities: ", identities_in_chunk->size());
+    thisAgent->outputManager->printa_sf(thisAgent, "\nLearned rule contained %u identities: ", static_cast<uint64_t>(identities_in_chunk->size()));
     for (auto it = identities_in_chunk->begin(); it != identities_in_chunk->end(); ++it)
     {
         thisAgent->outputManager->printa_sf(thisAgent, "%u ", (*it));

--- a/Core/SoarKernel/src/explanation_memory/instantiation_record.cpp
+++ b/Core/SoarKernel/src/explanation_memory/instantiation_record.cpp
@@ -257,7 +257,7 @@ void instantiation_record::print_for_wme_trace(bool isChunk, bool printFooter)
                     lInNegativeConditions = true;
                 }
             }
-            outputManager->printa_sf(thisAgent, "%d:%-", lConditionCount);
+            outputManager->printa_sf(thisAgent, "%d:%-", static_cast<int64_t>(lConditionCount));
 
             id_test_without_goal_test = copy_test(thisAgent, lCond->condition_tests.id, false, false, true);
 
@@ -324,7 +324,7 @@ void instantiation_record::print_for_explanation_trace(bool isChunk, bool printF
                 assert(rhs);
             } else {
                 outputManager->printa_sf(thisAgent, "Explanation trace of instantiation # %u %-(match of rule %y at level %d)\n",
-                    instantiationID, production_name, match_level);
+                    instantiationID, production_name, static_cast<int64_t>(match_level));
                 outputManager->printa_sf(thisAgent,
                     "\nWarning:  Cannot print explanation trace for this instantiation because no underlying\n"
                     "            rule found in RETE.  Printing working memory trace instead.\n\n");
@@ -358,7 +358,7 @@ void instantiation_record::print_for_explanation_trace(bool isChunk, bool printF
             outputManager->set_column_indent(2, 100);
             outputManager->set_column_indent(3, 115);
             outputManager->printa_sf(thisAgent, "Explanation trace of instantiation # %u %-(match of rule %y at level %d)\n\n",
-                instantiationID, production_name, match_level);
+                instantiationID, production_name, static_cast<int64_t>(match_level));
             outputManager->printa_sf(thisAgent, "%- %-Identities instead of variables %-Operational %-Creator\n\n");
         }
         thisAgent->outputManager->set_print_test_format(true, false);
@@ -373,7 +373,7 @@ void instantiation_record::print_for_explanation_trace(bool isChunk, bool printF
                 lInNegativeConditions = true;
             }
 
-            outputManager->printa_sf(thisAgent, "%d:%-", lConditionCount);
+            outputManager->printa_sf(thisAgent, "%d:%-", static_cast<int64_t>(lConditionCount));
 
             /* Get the next condition from the explanation trace.  This is tricky because NCCs are condition lists within condition lists */
             if (currentNegativeCond)
@@ -477,7 +477,7 @@ void instantiation_record::print_arch_inst_for_explanation_trace(bool isChunk, b
         outputManager->set_column_indent(3, 115);
         thisAgent->outputManager->set_print_test_format(true, false);
         outputManager->printa_sf(thisAgent, "Explanation trace of instantiation # %u %-(match of rule %y at level %d)\n",
-            instantiationID, production_name, match_level);
+            instantiationID, production_name, static_cast<int64_t>(match_level));
         thisAgent->explanationMemory->print_path_to_base(path_to_base, false, " (produced chunk result)", "- Shortest path to a result: ");
         outputManager->printa_sf(thisAgent, "\n%- %-Identities instead of variables %-Operational %-Creator\n\n");
 
@@ -495,7 +495,7 @@ void instantiation_record::print_arch_inst_for_explanation_trace(bool isChunk, b
                 lInNegativeConditions = false;
             }
 
-            outputManager->printa_sf(thisAgent, "%d:%-", lConditionCount);
+            outputManager->printa_sf(thisAgent, "%d:%-", static_cast<int64_t>(lConditionCount));
 
             outputManager->printa_sf(thisAgent, "(%t%s^%t %t%s)%-",
                 lCond->condition_tests.id, ((lCond->type == NEGATIVE_CONDITION) ? " -" : " "),

--- a/Core/SoarKernel/src/output_manager/output_manager.h
+++ b/Core/SoarKernel/src/output_manager/output_manager.h
@@ -269,7 +269,8 @@ inline const char* field_to_string(WME_Field f)
 }
 
 /* ------------------------------------
- *    Format strings for Soar printing:
+ *    Format strings for Soar printing; note that some of these do
+ *    not match their meaning in printf, etc.:
  *
  *       %c   character
  *       %d   int64_t

--- a/Core/SoarKernel/src/output_manager/soar_to_string.cpp
+++ b/Core/SoarKernel/src/output_manager/soar_to_string.cpp
@@ -584,7 +584,7 @@ void Output_Manager::cond_actions_to_string(agent* thisAgent, condition* top_con
 void Output_Manager::instantiation_to_string(agent* thisAgent, instantiation* inst, std::string &destString)
 {
     sprinta_sf(thisAgent, destString, "%sInstantiation (i %u) matched %y in state %y (level %d)\n",
-        m_pre_string, inst->i_id, inst->prod_name, inst->match_goal, inst->match_goal_level);
+        m_pre_string, inst->i_id, inst->prod_name, inst->match_goal, static_cast<int64_t>(inst->match_goal_level));
     cond_prefs_to_string(thisAgent, inst->top_of_instantiated_conditions, inst->preferences_generated, destString);
 }
 
@@ -615,7 +615,7 @@ void Output_Manager::print_all_inst(TraceMode mode)
 
     for (int y = 0; y < instantiation_list.size(); y++)
     {
-        print_sf("- Instantiation %d:\n", y);
+        print_sf("- Instantiation %d:\n", static_cast<int64_t>(y));
         print_sf("%7", instantiation_list[y]);
     }
 }
@@ -793,9 +793,9 @@ void Output_Manager::debug_find_and_print_sym(char* find_string)
                "  refcount = %d\n"
                "  tc_num   = %d\n",
                newSym,
-               newSym->symbol_type,
+               static_cast<int64_t>(newSym->symbol_type),
                newSym->reference_count,
-               newSym->tc_num);
+               static_cast<int64_t>(newSym->tc_num));
     }
     else
     {
@@ -809,7 +809,7 @@ bool om_print_sym(agent* thisAgent, void* item, void* vMode)
 
     if (!Output_Manager::Get_OM().is_trace_enabled(mode)) return false;
 
-    Output_Manager::Get_OM().printa_sf(thisAgent, "%y (%d)\n", static_cast<symbol_struct*>(item), static_cast<symbol_struct*>(item)->reference_count);
+    Output_Manager::Get_OM().printa_sf(thisAgent, "%y (%u)\n", static_cast<symbol_struct*>(item), static_cast<symbol_struct*>(item)->reference_count);
     return false;
 }
 

--- a/Core/SoarKernel/src/parsing/parser.cpp
+++ b/Core/SoarKernel/src/parsing/parser.cpp
@@ -583,7 +583,7 @@ test parse_test(agent* thisAgent, Lexer* lexer)
         }
     }
     while (lexer->current_lexeme.type != R_BRACE_LEXEME);
-    if (!lexer->get_lexeme()) 
+    if (!lexer->get_lexeme())
     {
         deallocate_test(thisAgent, t);
         return NULL;
@@ -1520,7 +1520,7 @@ rhs_value parse_function_call_after_lparen(agent* thisAgent,
     if ((rf->num_args_expected != -1) && (rf->num_args_expected != num_args))
     {
         thisAgent->outputManager->printa_sf(thisAgent,  "Wrong number of arguments to function %s (expected %d)\n",
-              rf->name->sc->name, rf->num_args_expected);
+              rf->name->sc->name, static_cast<int64_t>(rf->num_args_expected));
         deallocate_rhs_value(thisAgent, funcall_list_to_rhs_value(fl));
         return NIL;
     }

--- a/Core/SoarKernel/src/shared/soar_db.cpp
+++ b/Core/SoarKernel/src/shared/soar_db.cpp
@@ -25,14 +25,14 @@ namespace soar_module
     void sqlite_database::connect(const char* file_name, int flags)
     {
         int sqlite_err = sqlite3_open_v2(file_name, &(my_db), flags, NULL);
-        
+
         if (sqlite_err == SQLITE_OK)
         {
             set_status(connected);
-            
+
             set_errno(sqlite_err);
             set_errmsg(NULL);
-            
+
             #ifdef DEBUG_SQL_PROFILE
                 sqlite3_profile(my_db, &profile_sql, NULL);
             #endif
@@ -43,12 +43,12 @@ namespace soar_module
         else
         {
             set_status(problem);
-            
+
             set_errno(sqlite_err);
             set_errmsg(sqlite3_errmsg(my_db));
         }
     }
-    
+
     void sqlite_database::disconnect()
     {
         if (get_status() == connected)
@@ -57,14 +57,14 @@ namespace soar_module
             set_status(disconnected);
         }
     }
-    
+
     bool sqlite_database::backup(const char* file_name, std::string* err)
     {
         sqlite3* backup_db;
         bool return_val = false;
-        
+
         err->clear();
-        
+
         if (get_status() == connected)
         {
             int sqlite_err = sqlite3_open_v2(file_name, &(backup_db), (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE), NULL);
@@ -76,7 +76,7 @@ namespace soar_module
                     sqlite3_backup_step(backup_h, -1);
                     sqlite3_backup_finish(backup_h);
                 }
-                
+
                 if (sqlite3_errcode(backup_db) == SQLITE_OK)
                 {
                     return_val = true;
@@ -98,29 +98,29 @@ namespace soar_module
         {
             err->assign("Database is not currently connected.");
         }
-        
+
         return return_val;
     }
-    
+
     bool sqlite_database::print_table(const char* table_name)
     {
         sqlite3_stmt* statement;
         std::string query;
         query.assign("select * from ");
         query.append(table_name);
-        
+
         if (sqlite3_prepare(my_db, query.c_str(), -1, &statement, 0) == SQLITE_OK)
         {
             int ctotal = sqlite3_column_count(statement);
             int res = 0;
             const char* val;
 //                  std::string val;
-            
+
             fprintf(stderr, "----------------------------\n%s\n----------------------------\n", table_name);
             while (1)
             {
                 res = sqlite3_step(statement);
-                
+
                 if (res == SQLITE_ROW)
                 {
                     for (int i = 0; i < ctotal; i++)

--- a/Core/SoarKernel/src/shared/trace.cpp
+++ b/Core/SoarKernel/src/shared/trace.cpp
@@ -752,7 +752,7 @@ void print_trace_format_list(agent* thisAgent, trace_format* tf)
                 {
                     thisAgent->outputManager->printa(thisAgent, "%right[");
                 }
-                thisAgent->outputManager->printa_sf(thisAgent,  "%d,", tf->num);
+                thisAgent->outputManager->printa_sf(thisAgent,  "%d,", static_cast<int64_t>(tf->num));
                 print_trace_format_list(thisAgent, tf->data.subformat);
                 thisAgent->outputManager->printa(thisAgent, "]");
                 break;


### PR DESCRIPTION
Because Soar's custom output formatter uses non-standard specifiers (%u for uint64_t, %d for int64_t and %f for double), it's easy to get the type input types incorrect, which leads to undefined behavior. For example, in #342 Bob found that when printing the integer 0 with %d, garbage would be output because an extra 4 bytes of memory were read for the value. This could potentially lead to the program crashing due to accessing restricted memory.

Fix these everywhere using `static_cast`. Also fix some places where the specifiers were wrong in different ways (%u instead of %d, and %d instead of %p in one case).

Fixes #342.