### PR TITLE
Colors and Emoji on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: performance tests
         working-directory: ./out
-        run: ./do_performance_test.sh
+        run: sudo ./do_performance_test.sh
 
       - name: upload performance test results
         uses: actions/upload-artifact@v3

--- a/Core/shared/portability_posix.h
+++ b/Core/shared/portability_posix.h
@@ -182,5 +182,10 @@ inline double get_raw_time_per_usec()
 
 #endif
 
+inline bool stdout_supports_ansi_colors()
+{
+    return isatty(STDOUT_FILENO);
+}
+
 #endif // PORTABILITY_POSIX_H
 

--- a/Core/shared/portability_windows.h
+++ b/Core/shared/portability_windows.h
@@ -151,5 +151,18 @@ inline double get_raw_time_per_usec() {
 	}
 }
 
+inline bool stdout_supports_ansi_colors()
+{
+    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD mode = 0;
+    if (!GetConsoleMode(h, &mode))
+    {
+        fprintf(stderr, "Error determining console mode: %d. Assuming ansi colors not supported.\n", GetLastError());
+        return false;
+    }
+    return mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+}
+
+
 #endif // PORTABILITY_WINDOWS_H
 

--- a/PerformanceTests/PerformanceTests.cpp
+++ b/PerformanceTests/PerformanceTests.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     }
     if (!numDCs) numDCs = DEFAULT_DCS;
 
-    std::cout << "\e[1;31m" << agentname << "\e[0;37m" << ": ";
+    std::cout << "\033[1;31m" << agentname << "\033[0;37m" << ": ";
     if (numTrials > 1) std::cout << numTrials << " trials"; else std::cout << "single run";
     if (numDCs > 0) std::cout << ", " << numDCs << " DCs"; else std::cout << ", run forever";
     if (numInits > 0) std::cout << ", " << numInits << " extra init-soar/runs\n"; else std::cout << std::endl;

--- a/PerformanceTests/PerformanceTests.h
+++ b/PerformanceTests/PerformanceTests.h
@@ -101,12 +101,12 @@ class StatsTracker
         void PrintResultsHelper(std::ostream &outStream, std::string label, int label_width, double avg, double low, double high, bool useColors = false)
         {
             outStream.precision(4);
-            if (useColors) outStream << "\e[1;34m";
+            if (useColors) outStream << "\033[1;34m";
             outStream << std::resetiosflags(std::ios::right) << std::setiosflags(std::ios::left);
             outStream << std::setw(label_width) << label;
-            if (useColors) outStream << "\e[0;37m";
+            if (useColors) outStream << "\033[0;37m";
             outStream << ":";
-            if (useColors) outStream << "\e[0;93m";
+            if (useColors) outStream << "\033[0;93m";
             outStream << std::resetiosflags(std::ios::left);
             outStream << std::setiosflags(std::ios::right);
             outStream << std::setw(10) << std::setiosflags(std::ios::fixed) << std::setprecision(4) << avg;
@@ -115,7 +115,7 @@ class StatsTracker
             outStream << std::setw(10) << std::setiosflags(std::ios::fixed) << std::setprecision(4) << high;
 #endif
             outStream << std::setw(9) << std::setiosflags(std::ios::fixed) << std::setprecision(1) << (high ? ((high - low)/high)*100 : 0) << "%";
-            if (useColors) outStream << "\e[0;37m";
+            if (useColors) outStream << "\033[0;37m";
             outStream << std::endl;
         }
 };

--- a/PerformanceTests/do_performance_test.sh
+++ b/PerformanceTests/do_performance_test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 lVersion="9.6"
 lTestSuite="full"
 lUnitTests=off
@@ -94,5 +96,5 @@ if [ $lUnitTests != off ] ; then
   time nice -n -10 ./UnitTests -c ChunkingTests  > /dev/null
   echo "\nFunctional Tests"
   time nice -n -10 ./UnitTests -c FunctionalTests  > /dev/null
-fi 
+fi
 

--- a/SoarCLI/ansi_colors.h
+++ b/SoarCLI/ansi_colors.h
@@ -12,78 +12,78 @@ namespace ANSI_Color_Constants
 {
 
     // Reset
-    static const char* Off = "\e[0m";               // Text Reset
-    
+    static const char* Off = "\033[0m";               // Text Reset
+
     // Regular Colors
-    static const char* Black = "\e[0;30m";                // Black
-    static const char* Red = "\e[0;31m";                  // Red
-    static const char* Green = "\e[0;32m";                // Green
-    static const char* Yellow = "\e[0;33m";               // Yellow
-    static const char* Blue = "\e[0;34m";                 // Blue
-    static const char* Purple = "\e[0;35m";               // Purple
-    static const char* Cyan = "\e[0;36m";                 // Cyan
-    static const char* White = "\e[0;37m";                // White
-    
+    static const char* Black = "\033[0;30m";                // Black
+    static const char* Red = "\033[0;31m";                  // Red
+    static const char* Green = "\033[0;32m";                // Green
+    static const char* Yellow = "\033[0;33m";               // Yellow
+    static const char* Blue = "\033[0;34m";                 // Blue
+    static const char* Purple = "\033[0;35m";               // Purple
+    static const char* Cyan = "\033[0;36m";                 // Cyan
+    static const char* White = "\033[0;37m";                // White
+
     // Bold
-    static const char* BBlack = "\e[1;30m";               // Black
-    static const char* BRed = "\e[1;31m";                 // Red
-    static const char* BGreen = "\e[1;32m";               // Green
-    static const char* BYellow = "\e[1;33m";              // Yellow
-    static const char* BBlue = "\e[1;34m";                // Blue
-    static const char* BPurple = "\e[1;35m";              // Purple
-    static const char* BCyan = "\e[1;36m";                // Cyan
-    static const char* BWhite = "\e[1;37m";               // White
-    
+    static const char* BBlack = "\033[1;30m";               // Black
+    static const char* BRed = "\033[1;31m";                 // Red
+    static const char* BGreen = "\033[1;32m";               // Green
+    static const char* BYellow = "\033[1;33m";              // Yellow
+    static const char* BBlue = "\033[1;34m";                // Blue
+    static const char* BPurple = "\033[1;35m";              // Purple
+    static const char* BCyan = "\033[1;36m";                // Cyan
+    static const char* BWhite = "\033[1;37m";               // White
+
     // Underline
-    static const char* UBlack = "\e[4;30m";               // Black
-    static const char* URed = "\e[4;31m";                 // Red
-    static const char* UGreen = "\e[4;32m";               // Green
-    static const char* UYellow = "\e[4;33m";              // Yellow
-    static const char* UBlue = "\e[4;34m";                // Blue
-    static const char* UPurple = "\e[4;35m";              // Purple
-    static const char* UCyan = "\e[4;36m";                // Cyan
-    static const char* UWhite = "\e[4;37m";               // White
-    
+    static const char* UBlack = "\033[4;30m";               // Black
+    static const char* URed = "\033[4;31m";                 // Red
+    static const char* UGreen = "\033[4;32m";               // Green
+    static const char* UYellow = "\033[4;33m";              // Yellow
+    static const char* UBlue = "\033[4;34m";                // Blue
+    static const char* UPurple = "\033[4;35m";              // Purple
+    static const char* UCyan = "\033[4;36m";                // Cyan
+    static const char* UWhite = "\033[4;37m";               // White
+
     // Background
-    static const char* On_Black = "\e[40m";               // Black
-    static const char* On_Red = "\e[41m";                 // Red
-    static const char* On_Green = "\e[42m";               // Green
-    static const char* On_Yellow = "\e[43m";              // Yellow
-    static const char* On_Blue = "\e[44m";                // Blue
-    static const char* On_Purple = "\e[45m";              // Purple
-    static const char* On_Cyan = "\e[46m";                // Cyan
-    static const char* On_White = "\e[47m";               // White
-    
+    static const char* On_Black = "\033[40m";               // Black
+    static const char* On_Red = "\033[41m";                 // Red
+    static const char* On_Green = "\033[42m";               // Green
+    static const char* On_Yellow = "\033[43m";              // Yellow
+    static const char* On_Blue = "\033[44m";                // Blue
+    static const char* On_Purple = "\033[45m";              // Purple
+    static const char* On_Cyan = "\033[46m";                // Cyan
+    static const char* On_White = "\033[47m";               // White
+
     // High Intensity
-    static const char* IBlack = "\e[0;90m";               // Black
-    static const char* IRed = "\e[0;91m";                 // Red
-    static const char* IGreen = "\e[0;92m";               // Green
-    static const char* IYellow = "\e[0;93m";              // Yellow
-    static const char* IBlue = "\e[0;94m";                // Blue
-    static const char* IPurple = "\e[0;95m";              // Purple
-    static const char* ICyan = "\e[0;96m";                // Cyan
-    static const char* IWhite = "\e[0;97m";               // White
-    
+    static const char* IBlack = "\033[0;90m";               // Black
+    static const char* IRed = "\033[0;91m";                 // Red
+    static const char* IGreen = "\033[0;92m";               // Green
+    static const char* IYellow = "\033[0;93m";              // Yellow
+    static const char* IBlue = "\033[0;94m";                // Blue
+    static const char* IPurple = "\033[0;95m";              // Purple
+    static const char* ICyan = "\033[0;96m";                // Cyan
+    static const char* IWhite = "\033[0;97m";               // White
+
     // Bold High Intensity
-    static const char* BIBlack = "\e[1;90m";              // Black
-    static const char* BIRed = "\e[1;91m";                // Red
-    static const char* BIGreen = "\e[1;92m";              // Green
-    static const char* BIYellow = "\e[1;93m";             // Yellow
-    static const char* BIBlue = "\e[1;94m";               // Blue
-    static const char* BIPurple = "\e[1;95m";             // Purple
-    static const char* BICyan = "\e[1;96m";               // Cyan
-    static const char* BIWhite = "\e[1;97m";              // White
-    
+    static const char* BIBlack = "\033[1;90m";              // Black
+    static const char* BIRed = "\033[1;91m";                // Red
+    static const char* BIGreen = "\033[1;92m";              // Green
+    static const char* BIYellow = "\033[1;93m";             // Yellow
+    static const char* BIBlue = "\033[1;94m";               // Blue
+    static const char* BIPurple = "\033[1;95m";             // Purple
+    static const char* BICyan = "\033[1;96m";               // Cyan
+    static const char* BIWhite = "\033[1;97m";              // White
+
     // High Intensity backgrounds
-    static const char* On_IBlack = "\e[0;100m";           // Black
-    static const char* On_IRed = "\e[0;101m";             // Red
-    static const char* On_IGreen = "\e[0;102m";           // Green
-    static const char* On_IYellow = "\e[0;103m";          // Yellow
-    static const char* On_IBlue = "\e[0;104m";            // Blue
-    static const char* On_IPurple = "\e[0;105m";          // Purple
-    static const char* On_ICyan = "\e[0;106m";            // Cyan
-    static const char* On_IWhite = "\e[0;107m";           // White
-    
+    static const char* On_IBlack = "\033[0;100m";           // Black
+    static const char* On_IRed = "\033[0;101m";             // Red
+    static const char* On_IGreen = "\033[0;102m";           // Green
+    static const char* On_IYellow = "\033[0;103m";          // Yellow
+    static const char* On_IBlue = "\033[0;104m";            // Blue
+    static const char* On_IPurple = "\033[0;105m";          // Purple
+    static const char* On_ICyan = "\033[0;106m";            // Cyan
+    static const char* On_IWhite = "\033[0;107m";           // White
+
 //    static const char* Off = "";
 //
 //    // Regular Colors

--- a/SoarCLI/soar_cli.h
+++ b/SoarCLI/soar_cli.h
@@ -6,6 +6,7 @@
  * multicli (which was based on mincli) */
 
 #include "ElementXML.h"
+#include "portability.h"
 #include "sml_Client.h"
 #include "thread_Thread.h"
 #include "thread_Lock.h"
@@ -189,7 +190,7 @@ class SoarCLI
               #if defined(NO_COLORS)
                   m_color(false),
               #else
-                  m_color(true),
+                  m_color(stdout_supports_ansi_colors()),
               #endif
               m_listen(false), m_port(sml::Kernel::kUseAnyPort) {}
 

--- a/SoarCLI/soar_cli.h
+++ b/SoarCLI/soar_cli.h
@@ -186,7 +186,7 @@ class SoarCLI
         SoarCLI()
             : m_kernel(0), m_currentAgent(0), m_quit(false), m_isMultiAgent(false),
               m_longestAgentName(0), m_seen_newline(true),
-              #if defined(_WIN32) || defined(NO_COLORS)
+              #if defined(NO_COLORS)
                   m_color(false),
               #else
                   m_color(true),

--- a/UnitTests/SoarHelpers/SoarHelper.cpp
+++ b/UnitTests/SoarHelpers/SoarHelper.cpp
@@ -74,11 +74,7 @@ void SoarHelper::init_check_to_find_refcount_leaks(sml::Agent* agent)
         SoarHelper::agent_command(agent,"run 100");
         SoarHelper::agent_command(agent,"trace 1");
         SoarHelper::agent_command(agent,"soar init");
-#ifndef _WIN32
         std::cout << "✅ ";
-#else
-        std::cout << "Init passed.  Test ";
-#endif
         std::cout.flush();
     }
 }

--- a/UnitTests/TestHarness/testMain.cpp
+++ b/UnitTests/TestHarness/testMain.cpp
@@ -86,6 +86,11 @@ int main(int argc, char** argv)
     std::vector<std::string> expectedFailureTests;
     bool silent = false;
 
+    #if defined(_WIN32) || defined(WIN32)
+    // Allows printing emoji ✅
+    SetConsoleOutputCP(CP_UTF8);
+    #endif
+
     for (int index = 1; index < argc; ++index)
     {
         std::string argument(argv[index]);

--- a/UnitTests/TestHarness/testMain.cpp
+++ b/UnitTests/TestHarness/testMain.cpp
@@ -43,19 +43,8 @@
 #include "TestRunner.hpp"
 
 #if defined(_WIN32) || defined(WIN32)
-
-#   if (_MSC_VER == 1900)
-std::string OS = "Windows VS2015";
-#   elif (_MSC_VER == 1800)
-std::string OS = "Windows VS2013";
-#   elif (_MSC_VER == 1700)
-std::string OS = "Windows VS2012";
-#   elif (_MSC_VER == 1600)
-std::string OS = "Windows VS2010";
-#   else
-std::string OS = "Windows Prior to VS2010";
-#endif
-
+#include <sstream>
+std::string OS = static_cast<std::ostringstream&>(std::ostringstream() << "Microsoft C/C++ " << _MSC_FULL_VER).str();
 #elif defined(__APPLE__)
 std::string OS = "OS X";
 #elif defined(__linux__)

--- a/UnitTests/TestHarness/testMain.cpp
+++ b/UnitTests/TestHarness/testMain.cpp
@@ -297,13 +297,8 @@ int main(int argc, char** argv)
             }
             else if (!runner->failed)
             {
-#ifndef _WIN32
                 std::cout << "✅" << std::endl;
-#else
-                std::cout << "Passed." << std::endl;
-#endif
                 std::cout.flush();
-
                 xml << " />" << std::endl;
             }
             else if (runner->failed && (std::find(expectedFailureCategories.begin(), expectedFailureCategories.end(), category->getCategoryName()) != expectedFailureCategories.end() || std::find(expectedFailureTests.begin(), expectedFailureTests.end(), std::get<2>(test)) != expectedFailureTests.end()))


### PR DESCRIPTION
Windows Terminal and PowerShell both support emoji and colors, so there's no need to be precious about avoiding them on Windows anymore. We do need to make sure to use the more portable `\033`, as `\e` is only recognized by some languages/environments, and is not recognized in MSVC.