### PR TITLE
SMem fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,7 +252,7 @@ compile_commands.json
 
 # NUNIT
 *.VisualState.xml
-TestResult.xml
+TestResults.xml
 
 # Build Results of an ATL Project
 [Dd]ebugPS/

--- a/Core/CLI/src/cli_load_save.cpp
+++ b/Core/CLI/src/cli_load_save.cpp
@@ -212,6 +212,9 @@ bool CommandLineInterface::DoSave(std::vector<std::string>& argv, const std::str
             if (thisAgent->SMem->connected() && (thisAgent->SMem->statistics->nodes->get_value() > 0))
             {
                 result = thisAgent->SMem->export_smem(0, export_text, &(err));
+                if (!result) {
+                    SetError(*err);
+                }
                 AddSaveText("# Semantic Memory\n");
                 if (!DoCLog(LOG_ADD, 0, &export_text, true)) return false;
             } else {

--- a/Core/CLI/src/cli_smem.cpp
+++ b/Core/CLI/src/cli_smem.cpp
@@ -133,9 +133,11 @@ bool CommandLineInterface::DoSMem(const char pOp, const std::string* pArg1, cons
     }
     else if (pOp == 'i')
     {
-        /* Don't think we need clear out anything else any more */
-
-        thisAgent->SMem->reinit();
+        if (thisAgent->SMem->connected()) {
+            thisAgent->SMem->reinit();
+        } else {
+            thisAgent->SMem->attach();
+        }
 
         PrintCLIMessage("Semantic memory system re-initialized.");
         if (thisAgent->SMem->settings->append_db->get_value() == on)

--- a/Core/CLI/src/cli_smem.cpp
+++ b/Core/CLI/src/cli_smem.cpp
@@ -403,14 +403,13 @@ bool CommandLineInterface::DoSMem(const char pOp, const std::string* pArg1, cons
         std::string* err = new std::string("");
         uint64_t lti_id = NIL;
 
+        if (!thisAgent->SMem->connected())
+        {
+            return SetError("Cannot export smem: smem database not connected.");
+        }
+
         if (pArg2)
         {
-            thisAgent->SMem->attach();
-            if (!thisAgent->SMem->connected())
-            {
-                return SetError("Semantic memory database not connected.");
-            }
-
             const char* pAttr_c_str = pArg2->c_str();
             soar::Lexer lexer(thisAgent, pAttr_c_str);
             if (!lexer.get_lexeme()) return SetError("LTI not found.");
@@ -456,41 +455,8 @@ bool CommandLineInterface::DoSMem(const char pOp, const std::string* pArg1, cons
                 return false;
             }
 
-            PrintCLIMessage("Exported semantic memory to file.");
-        }
-        delete err;
-        return result;
-    }
-    else if (pOp == 'x')
-    {
-        std::string* err = new std::string("smem_export.soar");
-        uint64_t lti_id = NIL;
-
-        std::string export_text;
-        bool result = thisAgent->SMem->export_smem(0, export_text, &(err));
-
-        if (!result)
-        {
-            SetError(*err);
-        }
-        else
-        {
-            if (!DoCLog(LOG_NEW, err, 0, true))
-            {
-                return false;
-            }
-
-            if (!DoCLog(LOG_ADD, 0, &export_text, true))
-            {
-                return false;
-            }
-
-            if (!DoCLog(LOG_CLOSE, 0, 0, true))
-            {
-                return false;
-            }
-
-            PrintCLIMessage("Exported semantic memory to file.");
+            tempString << "Exported semantic memory to file '" << pArg1->c_str() << "'.";
+            PrintCLIMessage(&tempString);
         }
         delete err;
         return result;

--- a/Core/SoarKernel/src/semantic_memory/smem_print.cpp
+++ b/Core/SoarKernel/src/semantic_memory/smem_print.cpp
@@ -16,6 +16,10 @@
 bool SMem_Manager::export_smem(uint64_t lti_id, std::string& result_text, std::string** err_msg)
 {
     ltm_set store_set;
+    if (!connected()) {
+        (*err_msg)->append("Cannot export semantic memory if it is not connected.");
+        return false;
+    }
 
     if (!lti_id)
     {

--- a/UnitTests/SoarTestAgents/testRegression370.soar
+++ b/UnitTests/SoarTestAgents/testRegression370.soar
@@ -1,0 +1,10 @@
+# https://github.com/SoarGroup/Soar/issues/370
+# Make sure that smem --init connects smem DB so that --clear doesn't raise an error.
+smem --init
+smem --clear
+
+sp {pass
+	(state <S1>)
+-->
+	(succeeded)
+}

--- a/UnitTests/SoarUnitTests/MiscTests.cpp
+++ b/UnitTests/SoarUnitTests/MiscTests.cpp
@@ -285,6 +285,13 @@ void MiscTests::testWrongAgentWmeFunctions()
 
 }
 
+void MiscTests::testRegression370()
+{
+	source("testRegression370.soar");
+	agent->RunSelf(5000);
+	SoarHelper::init_check_to_find_refcount_leaks(agent);
+}
+
 void MiscTests::testRHSRand()
 {
 	kernel->AddRhsFunction("failed", Handlers::MyRhsFunctionFailureHandler, 0) ;

--- a/UnitTests/SoarUnitTests/MiscTests.hpp
+++ b/UnitTests/SoarUnitTests/MiscTests.hpp
@@ -33,6 +33,8 @@ public:
 
 	TEST(testWrongAgentWmeFunctions, -1)
 	void testWrongAgentWmeFunctions();
+	TEST(testRegression370, -1)
+	void testRegression370();
 	TEST(testRHSRand, -1)
 	void testRHSRand();
 	TEST(testMultipleKernels, -1)


### PR DESCRIPTION
2 fixes related to connecting the smem DB:

* Refuse to try to export the smem DB if it's not currently connected. Fixes a segfault (load Soar and do `smem -x foo.log` to replicate).
* Connect the DB when a user does `smem --init`. This allows users to put `smem --init` and `smem --clear` first thing in their project sources without any errors.

Fixes #370.