### PR TITLE
Reject ungrounded productions

### DIFF
--- a/Core/SoarKernel/src/explanation_based_chunking/ebc.cpp
+++ b/Core/SoarKernel/src/explanation_based_chunking/ebc.cpp
@@ -99,7 +99,6 @@ void Explanation_Based_Chunker::reinit()
     m_prod_name                         = NULL;
     chunk_free_problem_spaces           = NIL;
     chunky_problem_spaces               = NIL;
-    m_failure_type                      = ebc_success;
     m_rule_type                         = ebc_no_rule;
     m_learning_on_for_instantiation     = ebc_settings[SETTING_EBC_LEARNING_ON];
 }

--- a/Core/SoarKernel/src/explanation_based_chunking/ebc.h
+++ b/Core/SoarKernel/src/explanation_based_chunking/ebc.h
@@ -101,7 +101,6 @@ class Explanation_Based_Chunker
         /* Determines whether learning is on for a particular instantiation
          * based on the global learning settings and whether the state chunky */
         bool set_learning_for_instantiation(instantiation* inst);
-        void set_failure_type(EBCFailureType pFailure_type) {m_failure_type = pFailure_type; };
         void set_rule_type(ebc_rule_type pRuleType) {m_rule_type = pRuleType; };
         void reset_chunks_this_d_cycle() { chunks_this_d_cycle = 0; justifications_this_d_cycle = 0;};
 
@@ -200,7 +199,6 @@ class Explanation_Based_Chunker
         Symbol*             m_prod_name;
         ProductionType      m_prod_type;
         bool                m_should_print_name, m_should_print_prod;
-        EBCFailureType      m_failure_type;
 
         /* Core tables used by EBC during identity assignment during instantiation
          * creation. The data stored within them is temporary and cleared after use. */
@@ -250,6 +248,7 @@ class Explanation_Based_Chunker
         void            remove_chunk_instantiation();
         void            remove_from_chunk_cond_set(chunk_cond_set* set, chunk_cond* cc);
         bool            reorder_and_validate_chunk();
+        void            report_reorder_errors(ProdReorderFailureType reorder_result);
         void            deallocate_failed_chunk();
         void            clean_up(uint64_t pClean_up_id, soar_timer* pTimer = NULL);
         bool            add_chunk_to_rete();

--- a/Core/SoarKernel/src/explanation_based_chunking/ebc_build.cpp
+++ b/Core/SoarKernel/src/explanation_based_chunking/ebc_build.cpp
@@ -772,7 +772,6 @@ void Explanation_Based_Chunker::learn_rule_from_instance(instantiation* inst, in
     }
 
     m_inst = inst;
-    m_failure_type = ebc_success;
 
     if (!can_learn_from_instantiation()) { m_inst = NULL; return; }
 
@@ -1024,7 +1023,6 @@ void Explanation_Based_Chunker::clean_up (uint64_t pClean_up_id, soar_timer* pTi
     m_chunk_inst                        = NULL;
     m_prod_name                         = NULL;
     m_rule_type                         = ebc_no_rule;
-    m_failure_type                      = ebc_success;
 
     clear_symbol_identity_map();
     if (ebc_settings[SETTING_EBC_LEARNING_ON])

--- a/Core/SoarKernel/src/output_manager/output_errors.cpp
+++ b/Core/SoarKernel/src/output_manager/output_errors.cpp
@@ -17,50 +17,42 @@
 #include "ebc.h"
 #include "xml.h"
 
-void Output_Manager::display_ebc_error(agent* thisAgent, EBCFailureType pErrorType, const char* pString1, const char* pString2)
+void Output_Manager::display_reorder_error(agent* thisAgent, ProdReorderFailureType pErrorType, const char* pString1, const char* pString2)
 {
-    if (!thisAgent->trace_settings[TRACE_CHUNKS_WARNINGS_SYSPARAM]) return;
+    if (!thisAgent->outputManager->settings[OM_WARNINGS]) return;
     switch (pErrorType)
     {
-        case ebc_failed_reordering_rhs:
+        case reorder_failed_reordering_rhs:
         {
-//            thisAgent->explanationBasedChunker->print_current_built_rule("Attempted to add an invalid rule:");
-
-            printa_sf(thisAgent,  "%eThe following RHS actions contain variables that are not tested\n"
+            printa_sf(thisAgent,  "%eAttempted to add rule with ungrounded action(s).\n"
+                                  "The following RHS actions contain variables that are not tested\n"
                                   "in a positive condition on the LHS: \n\n"
                                   "%s\n", pString2);
             break;
         }
-        case ebc_failed_unconnected_conditions:
+        case reorder_failed_unconnected_conditions:
         {
-//            thisAgent->explanationBasedChunker->print_current_built_rule("Attempted to add an invalid rule:");
-
             printa_sf(thisAgent,"%eConditions on the LHS contain tests that are not connected \n"
                                 "to a goal: %s\n\n", pString2);
-            printa(thisAgent,   "   This is likely caused by a condition that tested a working memory element \n"
-                                "   that was created in the sub-state but later became connected to the \n"
-                                "   super-state because it was a child of an identifier that was an element\n"
-                                "   of a previous result in that same sub-state.\n");
             break;
         }
-        case ebc_failed_no_roots:
+        case reorder_failed_no_roots:
         {
-            thisAgent->explanationBasedChunker->print_current_built_rule("Attempted to add an invalid rule:");
-//            printa_sf(thisAgent,"\nChunking has created an invalid rule: %s\n\n", pString1);
-            printa(   thisAgent,  "   None of the conditions reference a goal state.\n");
+            printa_sf(thisAgent, "Error: production %s has no positive conditions that reference a goal state.\n"\
+                "Did you forget to add \"^type state\" or \"^superstate nil\"?\n",
+                thisAgent->name_of_production_being_reordered);
             break;
         }
-        case ebc_failed_negative_relational_test_bindings:
+        case reorder_failed_negative_relational_test_bindings:
         {
             thisAgent->explanationBasedChunker->print_current_built_rule("Attempted to add an invalid rule:");
-//            printa_sf(thisAgent,"\nChunking has created an invalid rule: %s\n\n", pString1);
             printa(thisAgent,  "   Unbound relational test in negative condition of rule \n");
             break;
         }
         default:
         {
             thisAgent->explanationBasedChunker->print_current_built_rule("Attempted to add an invalid rule:");
-            printa(thisAgent, "\nUnspecified chunking failure. That's weird.  Should report.\n\n");
+            printa(thisAgent, "\nUnspecified reordering/validation failure. That's weird. Should report.\n\n");
             printa_sf(thisAgent, "        %s\n", pString1);
         }
     }

--- a/Core/SoarKernel/src/output_manager/output_manager.h
+++ b/Core/SoarKernel/src/output_manager/output_manager.h
@@ -237,7 +237,7 @@ class Output_Manager
         /* A single function to print all pre-formatted Soar error messages.  Added
          * to make other code cleaner and easier to parse */
         void display_soar_feedback(agent* thisAgent, SoarCannedMessageType pErrorType, bool shouldPrint = true);
-        void display_ebc_error(agent* thisAgent, EBCFailureType pErrorType, const char* pString1 = NULL, const char* pString2 = NULL);
+        void display_reorder_error(agent* thisAgent, ProdReorderFailureType pErrorType, const char* pString1 = NULL, const char* pString2 = NULL);
         void display_ambiguous_command_error(agent* thisAgent, std::list< std::string > matched_objects_str);
 
         /* -- Should be moved elsewhere -- */

--- a/Core/SoarKernel/src/parsing/parser.cpp
+++ b/Core/SoarKernel/src/parsing/parser.cpp
@@ -1119,7 +1119,7 @@ condition* parse_tail_of_conds_for_one_id(agent* thisAgent, Lexer* lexer,
     if (lexer->current_lexeme.type == R_PAREN_LEXEME)
     {
         if (is_state_or_impasse_cond) {
-            thisAgent->outputManager->printa_sf(thisAgent,  "Expected attribute-value test "\
+            thisAgent->outputManager->printa_sf(thisAgent,  "Error: Expected attribute-value test "\
                 "after state/impasse test. Did you forget to add \"^type state\" or \"^superstate nil\"?\n");
             return nullptr;
         }
@@ -2460,7 +2460,7 @@ production* parse_production(agent* thisAgent, const char* prod_string, unsigned
     for (lhs_bottom = lhs; lhs_bottom->next != NIL; lhs_bottom = lhs_bottom->next);
 
     thisAgent->name_of_production_being_reordered = name->sc->name;
-    if (!reorder_and_validate_lhs_and_rhs(thisAgent, &lhs_top, &rhs, true))
+    if (reorder_and_validate_lhs_and_rhs(thisAgent, &lhs_top, &rhs, true) != reorder_success)
     {
         abort_parse_production(thisAgent, name, &documentation, &lhs, &rhs);
         return NIL;

--- a/Core/SoarKernel/src/reinforcement_learning/reinforcement_learning.cpp
+++ b/Core/SoarKernel/src/reinforcement_learning/reinforcement_learning.cpp
@@ -602,7 +602,7 @@ Symbol* rl_build_template_instantiation(agent* thisAgent, instantiation* my_temp
 
         // make new production
         thisAgent->name_of_production_being_reordered = new_name_symbol->sc->name;
-        if (new_action && reorder_and_validate_lhs_and_rhs(thisAgent, &cond_top, &new_action, false))
+        if (new_action && reorder_and_validate_lhs_and_rhs(thisAgent, &cond_top, &new_action, false) == reorder_success)
         {
             production* new_production = make_production(thisAgent, USER_PRODUCTION_TYPE, new_name_symbol, my_template->name->sc->name, &cond_top, &new_action, false, NULL);
 

--- a/Core/SoarKernel/src/shared/enums.h
+++ b/Core/SoarKernel/src/shared/enums.h
@@ -230,12 +230,12 @@ enum EBCTraceType {
     ebc_explanation_trace
 };
 
-enum EBCFailureType {
-    ebc_success,
-    ebc_failed_no_roots,
-    ebc_failed_negative_relational_test_bindings,
-    ebc_failed_reordering_rhs,
-    ebc_failed_unconnected_conditions
+enum ProdReorderFailureType {
+    reorder_success,
+    reorder_failed_no_roots,
+    reorder_failed_negative_relational_test_bindings,
+    reorder_failed_reordering_rhs,
+    reorder_failed_unconnected_conditions
 };
 
 enum EBCExplainStatus {

--- a/Core/SoarKernel/src/soar_representation/production.cpp
+++ b/Core/SoarKernel/src/soar_representation/production.cpp
@@ -348,22 +348,22 @@ bool action_is_in_tc(action* a, tc_number tc)
  * so EBC can first try to fix unconnected conditions before creating
  * the production. */
 
-bool reorder_and_validate_lhs_and_rhs(agent*        thisAgent,
-                                      condition**   lhs_top,
-                                      action**      rhs_top,
-                                      bool          reorder_nccs,
-                              matched_symbol_list*  ungrounded_syms,
-                                     bool           add_ungrounded_lhs,
-                                     bool           add_ungrounded_rhs)
+ProdReorderFailureType reorder_and_validate_lhs_and_rhs(agent*        thisAgent,
+                                                        condition**   lhs_top,
+                                                        action**      rhs_top,
+                                                        bool          reorder_nccs,
+                                                matched_symbol_list*  ungrounded_syms,
+                                                        bool          add_ungrounded_lhs,
+                                                        bool          add_ungrounded_rhs)
 {
     tc_number tc;
-    bool lhs_good = false;
 
     thisAgent->symbolManager->reset_variable_generator(*lhs_top, *rhs_top);
     tc = get_new_tc_number(thisAgent);
     add_bound_variables_in_condition_list(thisAgent, *lhs_top, tc, NIL);
 
-    if (! reorder_action_list(thisAgent, rhs_top, tc, ungrounded_syms, add_ungrounded_rhs))
+    auto rhs_reorder_result = reorder_action_list(thisAgent, rhs_top, tc, ungrounded_syms, add_ungrounded_rhs);
+    if (rhs_reorder_result != reorder_success)
     {
         /* If there are problems on the LHS, we need the ungrounded_syms
          * from them, before we return.  So we call, reorder_lhs too.
@@ -372,11 +372,9 @@ bool reorder_and_validate_lhs_and_rhs(agent*        thisAgent,
         {
             reorder_lhs(thisAgent, lhs_top, reorder_nccs, ungrounded_syms);
         }
-        return false;
+        return rhs_reorder_result;
     }
-    lhs_good = reorder_lhs(thisAgent, lhs_top, reorder_nccs, ungrounded_syms, add_ungrounded_lhs);
-    if (!lhs_good) return false;
-    return true;
+    return reorder_lhs(thisAgent, lhs_top, reorder_nccs, ungrounded_syms, add_ungrounded_lhs);
 }
 
 /* Note:  The rete load command will create a production without calling this.  Changes made here may

--- a/Core/SoarKernel/src/soar_representation/production.h
+++ b/Core/SoarKernel/src/soar_representation/production.h
@@ -156,13 +156,13 @@ void add_all_variables_in_condition_list(agent* thisAgent, condition* cond_list,
     say.  Normally deallocate_production() should be invoked only via
     the production_remove_ref() macro.
 ------------------------------------------------------------------- */
-bool reorder_and_validate_lhs_and_rhs(agent*                    thisAgent,
-                                      condition**               lhs_top,
-                                      action**                  rhs_top,
-                                      bool                      reorder_nccs,
-                                      matched_symbol_list*      ungrounded_syms = NULL,
-                                      bool                      add_ungrounded_lhs = false,
-                                      bool                      add_ungrounded_rhs = false
+ProdReorderFailureType reorder_and_validate_lhs_and_rhs(agent*                    thisAgent,
+                                                        condition**               lhs_top,
+                                                        action**                  rhs_top,
+                                                        bool                      reorder_nccs,
+                                                        matched_symbol_list*      ungrounded_syms = NULL,
+                                                        bool                      add_ungrounded_lhs = false,
+                                                        bool                      add_ungrounded_rhs = false
 );
 
 production* make_production(agent* thisAgent, ProductionType type,

--- a/Core/SoarKernel/src/soar_representation/production_reorder.h
+++ b/Core/SoarKernel/src/soar_representation/production_reorder.h
@@ -24,8 +24,8 @@ typedef struct saved_test_struct
     test                        the_test;
 } saved_test;
 
-extern bool reorder_action_list(agent* thisAgent, action** action_list, tc_number lhs_tc, matched_symbol_list* ungrounded_syms, bool add_ungrounded = false);
-extern bool reorder_lhs(agent* thisAgent, condition** lhs_top, bool reorder_nccs, matched_symbol_list* ungrounded_syms = NULL, bool add_ungrounded = false);
+extern ProdReorderFailureType reorder_action_list(agent* thisAgent, action** action_list, tc_number lhs_tc, matched_symbol_list* ungrounded_syms, bool add_ungrounded = false);
+extern ProdReorderFailureType reorder_lhs(agent* thisAgent, condition** lhs_top, bool reorder_nccs, matched_symbol_list* ungrounded_syms = NULL, bool add_ungrounded = false);
 extern void init_reorderer(agent* thisAgent);
 
 /* this prototype moved here from osupport.cpp -ajc (5/3/02) */

--- a/Core/SoarKernel/src/soar_representation/test.cpp
+++ b/Core/SoarKernel/src/soar_representation/test.cpp
@@ -271,9 +271,10 @@ bool add_test_merge_disjunctions(agent* thisAgent, test* dest_test_address, test
 
 
 /* ----------------------------------------------------------------
-   Destructively modifies the first test (t) by adding the second
-   one (add_me) to it (usually as a new conjunct).  The first test
-   need not be a conjunctive test nor even exist.
+   Destructively modifies *dest_test_address, always returning a
+   conjunct test that contains (at least) new_test.
+   dest_test_address need not be a conjunctive test nor even be
+   non-null.
 ---------------------------------------------------------------- */
 bool add_test(agent* thisAgent, test* dest_test_address, test new_test, bool merge_disjunctions)
 {

--- a/UnitTests/SoarTestAgents/testRegression370.soar
+++ b/UnitTests/SoarTestAgents/testRegression370.soar
@@ -4,7 +4,7 @@ smem --init
 smem --clear
 
 sp {pass
-	(state <S1>)
+	(state <S1> ^superstate nil)
 -->
 	(succeeded)
 }

--- a/UnitTests/SoarUnitTests/FullTests.cpp
+++ b/UnitTests/SoarUnitTests/FullTests.cpp
@@ -368,6 +368,33 @@ void FullTests_Parent::testProductions()
     SoarHelper::init_check_to_find_refcount_leaks(agent);
 }
 
+void FullTests_Parent::testUngroundedLHS()
+{
+    // This one is correct
+    agent->ExecuteCommandLine("sp { grounded (state <s> ^superstate nil) -->}");
+    no_agent_assertTrue(agent->GetLastCommandLineResult());
+
+    // Explicit ID test is not required on state
+    agent->ExecuteCommandLine("sp { grounded (state ^superstate nil) -->}");
+    no_agent_assertTrue(agent->GetLastCommandLineResult());
+
+    // TODO: this warns but should also fail, as there's no state test
+    agent->ExecuteCommandLine("sp {hello-world (<s> ^results <any>)-->}");
+    no_agent_assertTrue(agent->GetLastCommandLineResult());
+
+    // at least one attr/val test is required with state test
+    agent->ExecuteCommandLine("sp { ungrounded (state <s>) -->}");
+    no_agent_assertFalse(agent->GetLastCommandLineResult());
+
+    // We require the attr/val test to be in the same condition as the state test
+    agent->ExecuteCommandLine("sp { missing*attr*val*test (state <s>) (<s> ^superstate nil) -->}");
+    no_agent_assertFalse(agent->GetLastCommandLineResult());
+
+    // negative conditions do not serve to ground the state
+    agent->ExecuteCommandLine("sp { negative*doesnt*ground (state -^result <any>) -->}");
+    no_agent_assertFalse(agent->GetLastCommandLineResult());
+}
+
 void FullTests_Parent::testRHSHandler()
 {
     loadProductions(SoarHelper::GetResource("testsml.soar"));

--- a/UnitTests/SoarUnitTests/FullTests.hpp
+++ b/UnitTests/SoarUnitTests/FullTests.hpp
@@ -40,7 +40,7 @@ struct OptionsStruct
 	bool verbose;
 	bool remote;
 	bool autoCommitDisabled;
-	
+
 	void reset()
 	{
 		useClientThread = false;
@@ -56,6 +56,7 @@ class FullTests_Parent
 public:
 	void testInit();
 	void testProductions();
+    void testUngroundedLHS();
 	void testRHSHandler();
 	void testClientMessageHandler();
 	void testFilterHandler();
@@ -89,33 +90,33 @@ public:
 	void testCommandToFile();
 	void testConvertIdentifier();
 	void testOutputLinkRemovalOrdering();
-	
+
 	void before() { setUp(); }
 	void after(bool caught) { tearDown(caught); }
-	
+
 	virtual void setUp();
 	virtual void tearDown(bool caught);
-	
+
 	void createSoar();
 	void destroySoar();
 	int spawnListener();
 	void cleanUpListener();
-	
+
 	void loadProductions(std::string productions);
-	
+
 	OptionsStruct m_Options;
 	sml::Kernel* m_pKernel;
 	sml::Agent* agent;
-	
+
 	static const std::string kAgentName;
-	
+
 #ifdef _WIN32
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
 #else // _WIN32
 	pid_t pid;
 #endif // _WIN32
-	
+
 protected:
 	TestRunner* runner;
 };
@@ -124,117 +125,120 @@ class FullTests : public FullTests_Parent, public TestCategory
 {
 public:
 	TEST_CATEGORY(FullTests);
-	
+
 	TEST(testInit, -1);
 	void testInit() { this->FullTests_Parent::testInit(); }
-	
+
 	TEST(testProductions, -1);
 	void testProductions() { this->FullTests_Parent::testProductions(); }
-	
+
+    TEST(testUngroundedLHS, -1);
+    void testUngroundedLHS() { this->FullTests_Parent::testUngroundedLHS(); }
+
 	TEST(testRHSHandler, -1);
 	void testRHSHandler() { this->FullTests_Parent::testRHSHandler(); }
-	
+
 	TEST(testClientMessageHandler, -1);
 	void testClientMessageHandler() { this->FullTests_Parent::testClientMessageHandler(); }
-	
+
 	TEST(testFilterHandler, -1);
 	void testFilterHandler() { this->FullTests_Parent::testFilterHandler(); }
-	
+
 	TEST(testWMEs, -1);
 	void testWMEs() { this->FullTests_Parent::testWMEs(); }
-	
+
 	TEST(testXML, -1);
 	void testXML() { this->FullTests_Parent::testXML(); }
-	
+
 	TEST(testAgent, -1);
 	void testAgent() { this->FullTests_Parent::testAgent(); }
-	
+
 	TEST(testSimpleCopy, -1);
 	void testSimpleCopy() { this->FullTests_Parent::testSimpleCopy(); }
-	
+
 	TEST(testSimpleReteNetLoader, -1);
 	void testSimpleReteNetLoader() { this->FullTests_Parent::testSimpleReteNetLoader(); }
-	
+
 	TEST(test64BitReteNet, -1);
 	void test64BitReteNet() { this->FullTests_Parent::test64BitReteNet(); }
-	
+
 	TEST(testOSupportCopyDestroy, -1);
 	void testOSupportCopyDestroy() { this->FullTests_Parent::testOSupportCopyDestroy(); }
-	
+
 	TEST(testOSupportCopyDestroyCircularParent, -1);
 	void testOSupportCopyDestroyCircularParent() { this->FullTests_Parent::testOSupportCopyDestroyCircularParent(); }
-	
+
 	TEST(testOSupportCopyDestroyCircular, -1);
 	void testOSupportCopyDestroyCircular() { this->FullTests_Parent::testOSupportCopyDestroyCircular(); }
-	
+
 	TEST(testSynchronize, -1);
 	void testSynchronize() { this->FullTests_Parent::testSynchronize(); }
-	
+
 	TEST(testRunningAgentCreation, -1);
 	void testRunningAgentCreation() { this->FullTests_Parent::testRunningAgentCreation(); }
-	
+
 	TEST(testEventOrdering, -1);
 	void testEventOrdering() { this->FullTests_Parent::testEventOrdering(); }
-	
+
 	TEST(testStatusCompleteDuplication, -1);
 	void testStatusCompleteDuplication() { this->FullTests_Parent::testStatusCompleteDuplication(); }
-	
+
 	TEST(testStopSoarVsInterrupt, -1);
 	void testStopSoarVsInterrupt() { this->FullTests_Parent::testStopSoarVsInterrupt(); }
-	
+
 	TEST(testSharedWmeSetViolation, -1);
 	void testSharedWmeSetViolation() { this->FullTests_Parent::testSharedWmeSetViolation(); }
-	
+
 	TEST(testEchoEquals, -1);
 	void testEchoEquals() { this->FullTests_Parent::testEchoEquals(); }
-	
+
 	TEST(testFindAttrPipes, -1);
 	void testFindAttrPipes() { this->FullTests_Parent::testFindAttrPipes(); }
-	
+
 	TEST(testTemplateVariableNameBug, -1);
 	void testTemplateVariableNameBug() { this->FullTests_Parent::testTemplateVariableNameBug(); }
-	
+
 	TEST(testNegatedConjunctiveChunkLoopBug510, -1);
 	void testNegatedConjunctiveChunkLoopBug510() { this->FullTests_Parent::testNegatedConjunctiveChunkLoopBug510(); }
-	
+
 	TEST(testGDSBug1144, -1);
 	void testGDSBug1144() { this->FullTests_Parent::testGDSBug1144(); }
-	
+
 	TEST(testGDSBug1011, -1);
 	void testGDSBug1011() { this->FullTests_Parent::testGDSBug1011(); }
-	
+
 	TEST(testLearn, -1);
 	void testLearn() { this->FullTests_Parent::testLearn(); }
-	
+
     #ifndef NO_SVS
 	TEST(testSVS, -1);
     #endif
 	void testSVS() { this->FullTests_Parent::testSVS(); }
-	
+
 	TEST(testPreferenceSemantics, -1);
 	void testPreferenceSemantics() { this->FullTests_Parent::testPreferenceSemantics(); }
-	
+
 	TEST(testMatchTimeInterrupt, -1);
 	void testMatchTimeInterrupt() { this->FullTests_Parent::testMatchTimeInterrupt(); }
-	
+
 	TEST(testNegatedConjunctiveTestReorder, -1);
 	void testNegatedConjunctiveTestReorder() { this->FullTests_Parent::testNegatedConjunctiveTestReorder(); }
-	
+
 	TEST(testNegatedConjunctiveTestUnbound, -1);
 	void testNegatedConjunctiveTestUnbound() { this->FullTests_Parent::testNegatedConjunctiveTestUnbound(); }
-	
+
 	TEST(testCommandToFile, -1);
 	void testCommandToFile() { this->FullTests_Parent::testCommandToFile(); }
-	
+
 	TEST(testConvertIdentifier, -1);
 	void testConvertIdentifier() { this->FullTests_Parent::testConvertIdentifier(); }
-	
+
 	TEST(testOutputLinkRemovalOrdering, -1);
 	void testOutputLinkRemovalOrdering() { this->FullTests_Parent::testOutputLinkRemovalOrdering(); }
-	
+
 	void before() { setUp(); }
 	void after(bool caught) { tearDown(caught); }
-	
+
 	virtual void setUp();
 	virtual void tearDown(bool caught) { FullTests_Parent::tearDown(caught); }
 };


### PR DESCRIPTION
This change rejects productions like the one in #377 that have no positive attribute-value test on the state/impasse.  I think it makes Soar more beginner friendly, while also fixing a crash (#378).

For the reviewer: the TL;DR of changes to what Soar will allow for production syntax is in FullTests.cpp, in `void FullTests_Parent::testUngroundedLHS()`.