### PR TITLE
Add Python Source Distribution (sdist) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -508,6 +508,7 @@ wheelhouse/
 
 # pip/enscons build output
 soar_sml/
+/pyproject.toml
 
 ### Soar ###
 out/

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -70,7 +70,7 @@ requires = [
     # and other python build/install frontends (such as pip itself).
     #
     # We use a forked version of enscons to add python 3.12 support.
-    "enscons @ git+https://github.com/ShadowJonathan/enscons-soar@544f39f",
+    "enscons @ git+https://github.com/ShadowJonathan/enscons-soar@7d6f4ca",
 
     # Required sub-dependencies of enscons.
     "toml>=0.1",

--- a/Core/SConscript
+++ b/Core/SConscript
@@ -111,7 +111,7 @@ if not CheckSWIG(env):
 	print('SWIG not found. Will not define sml_* build targets. Install swig to build wrappers for other languages.')
 else:
 	for x in 'Python Java Tcl CSharp'.split():
-		SConscript(os.path.join('ClientSMLSWIG', x, 'SConscript'))
+		SConscript(os.path.join('ClientSMLSWIG', x, 'SConscript'), must_exist=False)
 
 if 'MSVSProject' in kernel_env['BUILDERS']:
 	vcproj = kernel_env.MSVSProject(

--- a/SConstruct
+++ b/SConstruct
@@ -431,7 +431,6 @@ if enscons_active:
 
     env.WhlFile(source=whl)
 
-    # env.FindSourceFiles(whl) +
     sdist_sources = env.Glob("Core/*/SConscript") + env.Glob("build_support/*.py") + [
         "SConstruct",
         "Core/SConscript",

--- a/SConstruct
+++ b/SConstruct
@@ -417,7 +417,6 @@ py_sources += [
 env.Alias(SML_PYTHON_ALIAS + "_dev", py_sources)
 
 if enscons_active:
-    env['PACKAGE_METADATA'] = enscons.get_pyproject(env)['project']
     # Instead of giving an explicit tag, we tell enscons that we're not building a "pure" (python-only) library,
     # and so we let it determine the wheel tag by itself.
     env['ROOT_IS_PURELIB'] = False
@@ -431,22 +430,42 @@ if enscons_active:
 
     env.WhlFile(source=whl)
 
-    sdist_sources = env.Glob("Core/*/SConscript") + env.Glob("build_support/*.py") + [
+    sdist_sources = [
+        # Add SCons related files
         "SConstruct",
         "Core/SConscript",
+        *env.Glob("Core/*/SConscript"),
         "Core/ClientSMLSWIG/Python/SConscript",
-        "Core/ClientSMLSWIG/Python/README.md",
-        "Core/SVS",
-    ] + env.Glob("Core/ClientSMLSWIG/Python/*.i") + env.Glob("Core/ClientSMLSWIG/*.i")
 
+        # Add SWIG files
+        *env.Glob("Core/ClientSMLSWIG/*.i"),
+        *env.Glob("Core/ClientSMLSWIG/Python/*.i"),
+
+        # Add build support files
+        *env.Glob("build_support/*.py"),
+
+        # Entire SVS source tree
+        "Core/SVS",
+
+        # Misc files
+        "Core/ClientSMLSWIG/Python/README.md",
+    ]
+
+    # Look for files under Core with the following file extensions, for up to 5 levels deep.
+    #
+    # We cannot just add the directories, as they will then start to include the .tar.gz file,
+    # which scons treats as a "target", creating a circular dependency.
+    SOURCE_EXTS = {"h", "c", "cpp", "hpp", "cxx"}
     for i in range(0, 5):
-        for ext in {"h", "c", "cpp", "hpp", "cxx"}:
+        for ext in SOURCE_EXTS:
             sdist_sources.extend(
                 env.Glob("Core/" + ("*/" * i) + "*." + ext)
             )
 
-    env.SDist(source=sdist_sources,
-              pyproject=True,
+    env.SDist(
+        source=sdist_sources,
+        # We tell enscons to include a generated / corrected pyproject.toml into the source distribution
+        pyproject=True,
     )
 
     # We make sure that an editable (`pip install -e`) installation always properly installs

--- a/SConstruct
+++ b/SConstruct
@@ -431,6 +431,25 @@ if enscons_active:
 
     env.WhlFile(source=whl)
 
+    # env.FindSourceFiles(whl) +
+    sdist_sources = env.Glob("Core/*/SConscript") + env.Glob("build_support/*.py") + [
+        "SConstruct",
+        "Core/SConscript",
+        "Core/ClientSMLSWIG/Python/SConscript",
+        "Core/ClientSMLSWIG/Python/README.md",
+        "Core/SVS",
+    ] + env.Glob("Core/ClientSMLSWIG/Python/*.i") + env.Glob("Core/ClientSMLSWIG/*.i")
+
+    for i in range(0, 5):
+        for ext in {"h", "c", "cpp", "hpp", "cxx"}:
+            sdist_sources.extend(
+                env.Glob("Core/" + ("*/" * i) + "*." + ext)
+            )
+
+    env.SDist(source=sdist_sources,
+              pyproject=True,
+    )
+
     # We make sure that an editable (`pip install -e`) installation always properly installs
     # the files in the correct places.
     env.Depends("editable", py_sources)


### PR DESCRIPTION
This PR depends on #448, and will remain a draft until it merges, and can be rebased.

---

This PR adds experimental "Source Distribution" (or; `sdist`) support for python packaging. Basically, `sdist` distributions are all source files necessary to build a package, so that when `pip` can't find a pre-built binary, it will pull the sdist `.tar.gz` file, and attempt to build it itself.

As you can guess, this is prone to failure, and is only meant as a last-resort usecase, the CI conditions in #448 aren't present on all machines that Soar would want to be installed on, nor have all edgecases been enumerated in the `SConstruct` file, to support building on a variety of targets.

Yet, I wanted to try, and this PR - at least experimentally - allows for the creation of an `sdist` `.tar.gz` file when ran with `python -m build Core/ClientSMLSWIG/Python --sdist`.

This file can then be uploaded to pypi alongside the binary `.whl` distributions, or installed locally with `pip install soar_sml-[...].tar.gz`

---

There is an argument to be had about "Should we even have this? We don't support every single system that's out there" and that's a fair point, which is why I separated this from #448, to talk/discuss that, and also to extend the invitation of *tons* of testing on all sorts of systems.

If `sdist` files are uploaded for any version of `soar-sml`, `pip` *will* attempt to build it, when it has no binary release to grab.

This may result in errors (as the system does not have the right build tools, or other conditions preventing its success), and may result in extra support requests (or other similar issues).