### PR TITLE
Add support for Python's "Limited API"; Test cibuildwheel and py >=3.5 using `TestPythonSML.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,9 @@ jobs:
         with:
           package-dir: Core/ClientSMLSWIG/Python/
 
+      - name: ABI3Audit
+        run: pipx run abi3audit -S -v wheelhouse/*
+
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,7 +344,8 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          # linux target which supports all python versions we want to install for
+          - ubuntu-20.04
             # latest available X86_64 target
           - macos-12
             # latest is ARM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,13 +311,26 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install swig
 
+      - name: Setup SWIG (windows-latest)
+        if: matrix.os == 'windows-latest'
+        uses: MinoruSekine/setup-scoop@v4
+        with:
+          apps: swig
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: Core/ClientSMLSWIG/Python/
 
-      - name: ABI3Audit
+      - name: ABI3Audit (*nix)
+        if: matrix.os != 'windows-latest'
         run: pipx run abi3audit -S -v wheelhouse/*
+
+      - name: ABI3Audit (Windows)
+        if: matrix.os == 'windows-latest'
+        # For windows we can't use glob expansion, so we need to enumerate the files manually.
+        # https://stackoverflow.com/a/16804630/8700553
+        run: Get-ChildItem -File wheelhouse | Foreach {pipx run abi3audit -S -v $_.fullname}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
     name: Test wheel on all python versions
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
           # linux target which supports all python versions we want to install for
@@ -391,14 +391,14 @@ jobs:
             3.${{ matrix.python-minor }}
             3.12
           # Latest version is installed under `python`
-
-      - name: Prepare install repo
-        run: pipx run piprepo build ./wheelhouse
+        env:
+          # Older python versions fail install if we dont do this: https://github.com/actions/setup-python/issues/866
+          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
       - name: Run python test command
         # TODO: replace with actual test command: https://github.com/SoarGroup/Soar/issues/460
         run: |
-          pip3.${{ matrix.python-minor }} install soar-sml -i ./wheelhouse/simple
+          pip3.${{ matrix.python-minor }} install soar-sml -f wheelhouse --no-index
           python3.${{ matrix.python-minor }} -c "import soar_sml;
           k=soar_sml.Kernel.CreateKernelInNewThread();
           a=k.CreateAgent('soar');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,10 +387,7 @@ jobs:
       - name: Setup Base Python
         uses: actions/setup-python@v4
         with:
-          python-version: |
-            3.${{ matrix.python-minor }}
-            3.12
-          # Latest version is installed under `python`
+          python-version: 3.${{ matrix.python-minor }}
         env:
           # Older python versions fail install if we dont do this: https://github.com/actions/setup-python/issues/866
           PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,7 +272,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [
-            ubuntu-latest,
+            # 20.04 to preserve compatibility with testing stage
+            ubuntu-20.04,
             # latest available X86_64 target
             macos-12,
             # latest is ARM
@@ -321,6 +322,19 @@ jobs:
         uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: Core/ClientSMLSWIG/Python/
+
+      - name: Ensure unit tests built (ubuntu-20.04)
+        if: matrix.os == 'ubuntu-20.04'
+        # On Ubuntu, we run cibuildwheel inside docker containers, which don't retain the outputs.
+        # However, we want out/SoarUnitTests/ to be availible for future tests, so we build it again here.
+        run: python scons/scons.py tests
+
+        # Save out/SoarUnitTests/
+      - uses: actions/cache/save@v3
+        id: cache
+        with:
+          path: out/SoarUnitTests/
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: ABI3Audit (*nix)
         if: matrix.os != 'windows-latest'
@@ -378,6 +392,9 @@ jobs:
       - Posix
       - Windows
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           pattern: cibw-wheels-*
@@ -392,14 +409,19 @@ jobs:
           # Older python versions fail install if we dont do this: https://github.com/actions/setup-python/issues/866
           PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
+        # Restore out/SoarUnitTests/
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: out/SoarUnitTests/
+          key: ${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Run python test command
         # TODO: replace with actual test command: https://github.com/SoarGroup/Soar/issues/460
         run: |
           pip3.${{ matrix.python-minor }} install soar-sml -f wheelhouse --no-index
-          python3.${{ matrix.python-minor }} -c "import soar_sml;
-          k=soar_sml.Kernel.CreateKernelInNewThread();
-          a=k.CreateAgent('soar');
-          assert(a.ExecuteCommandLine('echo hello world').strip()=='hello world')"
+          python3.${{ matrix.python-minor }} Core/ClientSMLSWIG/Python/TestPythonSML.py
 
   python_push_dev:
     name: Publish to test.pypi.org

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,14 +324,37 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
-  python_push_dev:
-    name: Publish to test.pypi.org
-    runs-on: ubuntu-latest
-    # - Upload only every monday to prevent spamming the index with too many build artifacts.
-    # - Allow uploading on manual workflow dispatch, to enable quick dev releases.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    # Alternative, to upload on every commit to development;
-    # if: github.event_name != 'schedule' && github.event_name != 'release'
+  test_python:
+    name: Test wheel on all python versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+            # latest available X86_64 target
+          - macos-12
+            # latest is ARM
+          - macos-latest
+        python-minor:
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+
+        # for macos-latest, we can't use python 3.5 - 3.7
+        exclude:
+          - os: macos-latest
+            python-minor: 5
+          - os: macos-latest
+            python-minor: 6
+          - os: macos-latest
+            python-minor: 7
+
     needs:
       # We depend on the python wheel builds because we need their artifacts
       - python_wheels
@@ -340,6 +363,43 @@ jobs:
       # usually then also the python wheel build should fail, but the normal builds do more thorough checking.
       - Posix
       - Windows
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-wheels-*
+          path: wheelhouse/
+          merge-multiple: true
+
+      - name: Setup Base Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.${{ matrix.python-minor }}
+            3.12
+          # Latest version is installed under `python`
+
+      - name: Prepare install repo
+        run: pipx run piprepo build ./wheelhouse
+
+      - name: Run python test command
+        # TODO: replace with actual test command: https://github.com/SoarGroup/Soar/issues/460
+        run: |
+          pip3.${{ matrix.python-minor }} install soar-sml -i ./wheelhouse/simple
+          python3.${{ matrix.python-minor }} -c "import soar_sml;
+          k=soar_sml.Kernel.CreateKernelInNewThread();
+          a=k.CreateAgent('soar');
+          assert(a.ExecuteCommandLine('echo hello world').strip()=='hello world')"
+
+  python_push_dev:
+    name: Publish to test.pypi.org
+    runs-on: ubuntu-latest
+    # - Upload only every monday to prevent spamming the index with too many build artifacts.
+    # - Allow uploading on manual workflow dispatch, to enable quick dev releases.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Alternative, to upload on every commit to development;
+    # if: github.event_name != 'schedule' && github.event_name != 'release'
+
+    needs: test_python
 
     # We use Trusted Publishing to manage our access to pypi:
     # https://github.com/marketplace/actions/pypi-publish#trusted-publishing
@@ -373,14 +433,7 @@ jobs:
     name: Publish to pypi.org
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs:
-      # We depend on the python wheel builds because we need their artifacts
-      - python_wheels
-
-      # We depend on the builds themselves to gatekeep the upload if build + testing fails,
-      # usually then also the python wheel build should fail, but the normal builds do more thorough checking.
-      - Posix
-      - Windows
+    needs: test_python
 
     # We use Trusted Publishing to manage our access to pypi:
     # https://github.com/marketplace/actions/pypi-publish#trusted-publishing

--- a/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
+++ b/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
@@ -12,7 +12,9 @@
 %include <windows.i>
 
 %begin %{
+#ifdef Soar_Python_ABI3
 #define Py_LIMITED_API 0x03050000
+#endif
 %}
 
 %{

--- a/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
+++ b/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
@@ -11,12 +11,6 @@
 // handle windows calling convention, __declspec(dllimport), correctly
 %include <windows.i>
 
-%begin %{
-#ifdef Soar_Python_ABI3
-#define Py_LIMITED_API 0x03050000
-#endif
-%}
-
 %{
 	// helps quell warnings
 	#ifndef unused

--- a/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
+++ b/Core/ClientSMLSWIG/Python/Python_sml_ClientInterface.i
@@ -11,6 +11,10 @@
 // handle windows calling convention, __declspec(dllimport), correctly
 %include <windows.i>
 
+%begin %{
+#define Py_LIMITED_API 0x03050000
+%}
+
 %{
 	// helps quell warnings
 	#ifndef unused
@@ -252,7 +256,10 @@
 			return "";
 		}
 
-		std::string res = PyUnicode_AsUTF8 (result);
+		PyObject* unicode = PyUnicode_AsUTF8String (result);
+		std::string res = PyBytes_AsString(unicode);
+
+		Py_DECREF(unicode);
 		Py_DECREF(result);
 
 		PyGILState_Release(gstate); /* Release the thread. No Python API allowed beyond this point. */
@@ -303,7 +310,10 @@
 			return "";
 		}
 
-		std::string res = PyUnicode_AsUTF8 (result);
+		PyObject* unicode = PyUnicode_AsUTF8String (result);
+		std::string res = PyBytes_AsString(unicode);
+
+		Py_DECREF(unicode);
 		Py_DECREF(result);
 
 		PyGILState_Release(gstate); /* Release the thread. No Python API allowed beyond this point. */

--- a/Core/ClientSMLSWIG/Python/SConscript
+++ b/Core/ClientSMLSWIG/Python/SConscript
@@ -70,6 +70,8 @@ if "SOAR_PYTHON_ABI3" in env["ENV"]:
         print("PY_ABI3_VERSION below supported version for ABI3", file=sys.stderr)
         Exit(1)
 
+    # Only SWIG 4.2.0 added Python Limited API support:
+    # https://github.com/swig/swig/issues/1009
     if env["SWIG_VERSION"] >= (4, 2, 0):
         print("SOAR_PYTHON_ABI3 defined, building Python Limited API...")
         # Signal to enscons that we're building the limited API

--- a/Core/ClientSMLSWIG/Python/SConscript
+++ b/Core/ClientSMLSWIG/Python/SConscript
@@ -59,6 +59,18 @@ install_source = env.Install(lib_install_dir, source)
 install_lib = env.Install(lib_install_dir, shlib)
 install_test = env.Install(lib_install_dir, env.File('TestPythonSML.py'))
 
+if "SOAR_PYTHON_ABI3" in env["ENV"]:
+    if env["SWIG_VERSION"] >= (4, 2, 0):
+        print("SOAR_PYTHON_ABI3 defined, building Python Limited API...")
+        # Signal to SConstruct that we're building the limited API
+        env["PYTHON_LIMITED_API"] = True
+        # Signal to the .i file that we're building the limited API
+        clone.Append(CPPDEFINES = { 'Soar_Python_ABI3': None })
+    else:
+        print("'Requested building Python SML bindings with Python's Limited API, "
+              "while SWIG does not support it, aborting.'", file=sys.stderr)
+        Exit(1)
+
 # We add soarlib to the python_sml explicitly, as some operating systems don't pick up on this dependency,
 # and crash the build.
 Import('soarlib')

--- a/Core/ClientSMLSWIG/Python/SConscript
+++ b/Core/ClientSMLSWIG/Python/SConscript
@@ -60,12 +60,27 @@ install_lib = env.Install(lib_install_dir, shlib)
 install_test = env.Install(lib_install_dir, env.File('TestPythonSML.py'))
 
 if "SOAR_PYTHON_ABI3" in env["ENV"]:
+    if env.get('PY_ABI3_VERSION', None) is None:
+        print("SOAR_PYTHON_ABI3 requested, but PY_ABI3_VERSION was not defined in env, aborting.", file=sys.stderr)
+        Exit(1)
+    elif not isinstance(env["PY_ABI3_VERSION"], tuple) or len(env["PY_ABI3_VERSION"]) != 2:
+        print("PY_ABI3_VERSION malformed, expected 2-tuple.", file=sys.stderr)
+        Exit(1)
+    elif env["PY_ABI3_VERSION"] < (3, 2):
+        print("PY_ABI3_VERSION below supported version for ABI3", file=sys.stderr)
+        Exit(1)
+
     if env["SWIG_VERSION"] >= (4, 2, 0):
         print("SOAR_PYTHON_ABI3 defined, building Python Limited API...")
-        # Signal to SConstruct that we're building the limited API
-        env["PYTHON_LIMITED_API"] = True
+        # Signal to enscons that we're building the limited API
+        # also deconstruct (major, minor) tuple
+        major, minor = env["LIMITED_API_TARGET"] = env["PY_ABI3_VERSION"]
+
+        # CPP Definition constructed from the minor/major ABI3 version parts
+        API_NUMBER = (0x1000000 * major) + (0x10000 * minor)
+
         # Signal to the .i file that we're building the limited API
-        clone.Append(CPPDEFINES = { 'Soar_Python_ABI3': None })
+        clone.Append(CPPDEFINES = { 'Py_LIMITED_API': None })
     else:
         print("'Requested building Python SML bindings with Python's Limited API, "
               "while SWIG does not support it, aborting.'", file=sys.stderr)

--- a/Core/ClientSMLSWIG/Python/SConscript
+++ b/Core/ClientSMLSWIG/Python/SConscript
@@ -77,10 +77,10 @@ if "SOAR_PYTHON_ABI3" in env["ENV"]:
         major, minor = env["LIMITED_API_TARGET"] = env["PY_ABI3_VERSION"]
 
         # CPP Definition constructed from the minor/major ABI3 version parts
-        API_NUMBER = (0x1000000 * major) + (0x10000 * minor)
+        api_version = (0x1000000 * major) + (0x10000 * minor)
 
         # Signal to the .i file that we're building the limited API
-        clone.Append(CPPDEFINES = { 'Py_LIMITED_API': None })
+        clone.Append(CPPDEFINES = { 'Py_LIMITED_API': api_version })
     else:
         print("'Requested building Python SML bindings with Python's Limited API, "
               "while SWIG does not support it, aborting.'", file=sys.stderr)

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -127,6 +127,7 @@ skip = [
 #
 # We pick python 3.9, since macOS ARM64 doesn't have 3.8, and so this is the earliest version on all platforms.
 build = "cp39*"
+environment = { SOAR_PYTHON_ABI3="1" }
 # This test command:
 #  - imports soar_sml
 #  - creates the kernel

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -70,7 +70,7 @@ requires = [
     # and other python build/install frontends (such as pip itself).
     #
     # We use a forked version of enscons to add python 3.12 support.
-    "enscons @ git+https://github.com/ShadowJonathan/enscons-soar@544f39f",
+    "enscons @ git+https://github.com/ShadowJonathan/enscons-soar@190091866ac35fb5d390c425bafaf13443baee5e",
 
     # Required sub-dependencies of enscons.
     "toml>=0.1",

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -129,23 +129,21 @@ skip = [
 build = "cp39*"
 # Inside CIs, we want to build the limited API, as we control SWIG's version there, so we opt-in.
 environment = { SOAR_PYTHON_ABI3="1" }
-# This test command:
-#  - imports soar_sml
-#  - creates the kernel
-#  - creates an agent
-#  - executes a command on that agent
-#  - fails if the result of this command isn't as expected
-# to test if Soar properly boots and runs.
-test-command = """\
-python -c "import soar_sml;\
-k=soar_sml.Kernel.CreateKernelInNewThread();\
-a=k.CreateAgent('soar');\
-assert(a.ExecuteCommandLine('echo hello world').strip()=='hello world')"
-"""
+# Create the unit tests under out/SoarUnitTests/
+before-test = "python scons/scons.py tests"
+# This test command will ruin the unit tests to make sure the build succeeded without oddities.
+test-command = "SOAR_UNIT_TEST_BASE_DIR={project}/out/ python {project}/Core/ClientSMLSWIG/Python/TestPythonSML.py"
 
 # Skip testing python 3.8 on ARM64. This is due to a limitation with cibuildwheel:
 # https://github.com/pypa/cibuildwheel/pull/1169#issuecomment-1178727618
 test-skip = "cp38-macosx_*:arm64"
+
+[tool.cibuildwheel.windows]
+# For windows we need a slightly different command
+test-command = """\
+set SOAR_UNIT_TEST_BASE_DIR={project}/out/
+python {project}/Core/ClientSMLSWIG/Python/TestPythonSML.py
+"""
 
 [tool.cibuildwheel.linux]
 # Specific instructions for cibuildwheel when running on linux:

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -50,7 +50,7 @@ authors = [
     { name = "Y. Wang" },
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.5"
 dependencies = []
 keywords = ["soar", "sml", "cog-arch", "cognitive architecture", "cognitive", "soar-sml", "ai"]
 classifiers = [

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -123,6 +123,10 @@ skip = [
     # which would be a duplicate with the x86 runner.
     "cp38-macosx_arm64"
 ]
+# We only need one target to build on, since we test all versions later.
+#
+# We pick python 3.9, since macOS ARM64 doesn't have 3.8, and so this is the earliest version on all platforms.
+build = "cp39*"
 # This test command:
 #  - imports soar_sml
 #  - creates the kernel

--- a/Core/ClientSMLSWIG/Python/pyproject.toml
+++ b/Core/ClientSMLSWIG/Python/pyproject.toml
@@ -127,6 +127,7 @@ skip = [
 #
 # We pick python 3.9, since macOS ARM64 doesn't have 3.8, and so this is the earliest version on all platforms.
 build = "cp39*"
+# Inside CIs, we want to build the limited API, as we control SWIG's version there, so we opt-in.
 environment = { SOAR_PYTHON_ABI3="1" }
 # This test command:
 #  - imports soar_sml

--- a/Core/SConscript
+++ b/Core/SConscript
@@ -16,20 +16,27 @@ def recursive_glob(treeroot, pattern):
 	return results
 # 	('SoarKernel/SoarKernel.cxx',       recursive_glob(kernel_env.Dir('SoarKernel/src').abspath(), '*.cpp')),    # Kernel
 
-def CheckSWIG(env):
+def SWIGVersion(env):
 	if not env.WhereIs('swig'):
-		return False
-
+		return None
 	p = sub.Popen('swig -version'.split(), stdout=sub.PIPE)
 	out = p.communicate()[0].decode().split()
 	p.wait()
 
-	version = tuple(int(x) for x in out[2].split('.'))
+	return tuple(int(x) for x in out[2].split('.'))
+
+
+def CheckSWIG(env):
+	version = SWIGVersion(env)
+	if version is None:
+		return False
+
 	if version >= (1, 3, 31):
 		return True
 
 	print('swig version 1.3.31 or higher is required')
 	return False
+
 
 kernel_env = env.Clone()
 
@@ -110,6 +117,7 @@ env.Alias('headers', headers)
 if not CheckSWIG(env):
 	print('SWIG not found. Will not define sml_* build targets. Install swig to build wrappers for other languages.')
 else:
+	env["SWIG_VERSION"] = SWIGVersion(env)
 	for x in 'Python Java Tcl CSharp'.split():
 		SConscript(os.path.join('ClientSMLSWIG', x, 'SConscript'))
 

--- a/SConstruct
+++ b/SConstruct
@@ -417,7 +417,6 @@ py_sources += [
 env.Alias(SML_PYTHON_ALIAS + "_dev", py_sources)
 
 if enscons_active:
-    env['PACKAGE_METADATA'] = enscons.get_pyproject(env)['project']
     # Instead of giving an explicit tag, we tell enscons that we're not building a "pure" (python-only) library,
     # and so we let it determine the wheel tag by itself.
     env['ROOT_IS_PURELIB'] = False

--- a/SConstruct
+++ b/SConstruct
@@ -421,6 +421,9 @@ if enscons_active:
     # and so we let it determine the wheel tag by itself.
     env['ROOT_IS_PURELIB'] = False
 
+    # This enables tagging the wheel with the limited api, and also sets the target python version.
+    env["LIMITED_API_TARGET"] = (3, 5)
+
     # Whl and WhlFile add multiple targets (sdist, dist_info, bdist_wheel, editable) to env
     # for enscons (python build backend for scons; required for building with cibuildwheel).
     whl = env.Whl("platlib", py_sources, root="")

--- a/SConstruct
+++ b/SConstruct
@@ -172,6 +172,7 @@ env = Environment(
     SOAR_VERSION=SOAR_VERSION,
     VISHIDDEN=False,  # needed by swig
 	JAVAVERSION='11.0',
+    PY_ABI3_VERSION = (3, 5),
     SML_CSHARP_ALIAS = SML_CSHARP_ALIAS,
     SML_JAVA_ALIAS = SML_JAVA_ALIAS,
     SML_PYTHON_ALIAS = SML_PYTHON_ALIAS,
@@ -420,10 +421,6 @@ if enscons_active:
     # Instead of giving an explicit tag, we tell enscons that we're not building a "pure" (python-only) library,
     # and so we let it determine the wheel tag by itself.
     env['ROOT_IS_PURELIB'] = False
-
-    if env.get('PYTHON_LIMITED_API', False):
-        # This enables tagging the wheel with the limited api, and also sets the target python version.
-        env["LIMITED_API_TARGET"] = (3, 5)
 
     # Whl and WhlFile add multiple targets (sdist, dist_info, bdist_wheel, editable) to env
     # for enscons (python build backend for scons; required for building with cibuildwheel).

--- a/SConstruct
+++ b/SConstruct
@@ -421,8 +421,9 @@ if enscons_active:
     # and so we let it determine the wheel tag by itself.
     env['ROOT_IS_PURELIB'] = False
 
-    # This enables tagging the wheel with the limited api, and also sets the target python version.
-    env["LIMITED_API_TARGET"] = (3, 5)
+    if env.get('PYTHON_LIMITED_API', False):
+        # This enables tagging the wheel with the limited api, and also sets the target python version.
+        env["LIMITED_API_TARGET"] = (3, 5)
 
     # Whl and WhlFile add multiple targets (sdist, dist_info, bdist_wheel, editable) to env
     # for enscons (python build backend for scons; required for building with cibuildwheel).


### PR DESCRIPTION
Resolves #458
Resolves #460

This pivots scons to build for a single "limited API" that stays future-proof for all python 3 versions, following a single one it is built for.

This also tests all those versions that it is then supporting. This is done in parallel, so that it impacts CI times minimally. (and adds 30 seconds max)

This'll only build the `abi3` wheels if `SOAR_PYTHON_ABI3` is defined at the time of building. The output wheels are appropriately tagged, so that version mixing does not happen.

(This environment variable makes the building of `abi3` wheels completely optional, python-version-specific wheels will be created without it (like before), which should be alright for development installs and the likes)

---

This PR also has cibuildwheel call and run `TestPytonSML.py` to more thoroughly test its wheels.

This change is also added to the above OS+PyVersion testing matrix.