### PR TITLE
Fix for issue #500

### DIFF
--- a/Core/SVS/src/serialize.cpp
+++ b/Core/SVS/src/serialize.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cstring>
 #include "common.h"
+#include "portability.h"
 #include "serialize.h"
 
 void serialize(const serializable& v, std::ostream& os)

--- a/Core/SoarKernel/src/shared/soar_instance.h
+++ b/Core/SoarKernel/src/shared/soar_instance.h
@@ -11,6 +11,7 @@
 #include "kernel.h"
 #include "Export.h"
 
+#include <string>
 #include <unordered_map>
 
 typedef void* (*MessageFunction)(const char* pMessage, void* pMessageData);


### PR DESCRIPTION
Per issue #500, this adds two `#include` directives, one for `<string>` in `soar_instance.h` and the other for `"portability.h"` in `serialize.cpp`.