### PR TITLE
fixed a dead url and using atomic operations on 32 bit architectures on modern gcc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: [windows-latest]
     env:
       TCL_HOME: c:\progra~1\tcl
-      TCL_DOWNLOAD_URL: https://kumisystems.dl.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8613-src.zip
+      TCL_DOWNLOAD_URL: https://master.dl.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8613-src.zip
       EXPECTED_TCL_HASH: 8999fcafab2d85473280e0bf6e390480496dfd53
 
     steps:

--- a/Core/shared/portability_posix.h
+++ b/Core/shared/portability_posix.h
@@ -97,9 +97,9 @@
 
 #define NET_SD_BOTH         SHUT_RDWR
 
-#if (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 2 || (__GNUC_MINOR__ == 2)))) && (!defined(__i386__) && !defined(__i486__) && !defined(__i586__) && !defined(__i686__))
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4))) || ((__GNUC__ == 4 && __GNUC_MINOR__ >= 2 && __GNUC_MINOR__ < 4) && (!defined(__i386__) && !defined(__i486__) && !defined(__i586__) && !defined(__i686__)))
 // requires GCC>=4.2.0
-// additionally fails at link time on i386/i486/i586/i686
+// additionally fails at link time on i386/i486/i586/i686 // sjj -- attempting to change so that 32 bit modern gcc with atomic operations works.
 static inline long atomic_inc(volatile long*  v)
 {
     return __sync_add_and_fetch(v, 1);


### PR DESCRIPTION
There was a reference counting error in a tower of hanoi test where a thread was using something decremented to 0. Should be fixed.