### PR TITLE
Fixing a bug where chunks were being refcount decremented during stat…

### DIFF
--- a/Core/SoarKernel/src/soar_representation/instantiation.cpp
+++ b/Core/SoarKernel/src/soar_representation/instantiation.cpp
@@ -1386,7 +1386,7 @@ void deallocate_instantiation(agent* thisAgent, instantiation*& inst)
                  * rete.cpp.  But if removing the preference will remove the instantiation, we
                  * need to excise it now so that the rete doesn't try to later */
                 excise_production(thisAgent, lDelInst->prod, false, true);
-            } else {
+            } else if (lDelInst->prod->type == JUSTIFICATION_PRODUCTION_TYPE) {
                 production_remove_ref(thisAgent, lDelInst->prod);
             }
         }


### PR DESCRIPTION
…e cleanup where justifications were the only things needing special processing (in the case of OSK knowledge having kept structures around because they might need backtracing through)